### PR TITLE
Encumbrance fixes

### DIFF
--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -594,11 +594,11 @@ export class OseActor extends Actor {
     if (["detailed", "complete"].includes(option)) {
       if (weight > data.encumbrance.max) {
         data.movement.base = 0;
-      } else if (weight > 800 + delta) {
+      } else if (weight >= 800 + delta) {
         data.movement.base = 30;
-      } else if (weight > 600 + delta) {
+      } else if (weight >= 600 + delta) {
         data.movement.base = 60;
-      } else if (weight > 400 + delta) {
+      } else if (weight >= 400 + delta) {
         data.movement.base = 90;
       } else {
         data.movement.base = 120;
@@ -629,7 +629,7 @@ export class OseActor extends Actor {
           data.movement.base = 60;
           break;
       }
-      if (weight > game.settings.get("ose", "significantTreasure")) {
+      if (weight >= game.settings.get("ose", "significantTreasure")) {
         data.movement.base -= 30;
       }
     }

--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -595,7 +595,7 @@ export class OseActor extends Actor {
     const weight = data.encumbrance.value;
     const delta = data.encumbrance.max - 1600;
     if (["detailed", "complete"].includes(option)) {
-      if (weight > data.encumbrance.max) {
+      if (weight >= data.encumbrance.max) {
         data.movement.base = 0;
       } else if (weight >= 800 + delta) {
         data.movement.base = 30;

--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -545,8 +545,8 @@ export class OseActor extends Actor {
     let option = game.settings.get("ose", "encumbranceOption");
     const items = [...this.data.items.values()];
     // Compute encumbrance
-    const hasItems = items.every((item) => {
-      return item.type != "item" && !item.data.treasure;
+    const hasItems = items.some((item) => {
+      return item.type === "item" && !item.data.treasure;
     });
 
     let totalWeight = items.reduce((acc, item) => {

--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -603,14 +603,17 @@ export class OseActor extends Actor {
       } else {
         data.movement.base = 120;
       }
-    } else if (option == "basic") {
-      const armors = this.data.items.filter((i) => i.type == "armor");
+    } else if (option === "basic") {
+      const armors = this.data.items.filter((i) => i.type === "armor");
       let heaviest = 0;
       armors.forEach((a) => {
-        if (a.data.equipped) {
-          if (a.data.type == "light" && heaviest == 0) {
+        let armorData = a.data.data;
+        let weight = armorData.type;
+        let equipped = armorData.equipped;
+        if (equipped) {
+          if (weight === "light" && heaviest === 0) {
             heaviest = 1;
-          } else if (a.data.type == "heavy") {
+          } else if (weight === "heavy") {
             heaviest = 2;
           }
         }

--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -591,9 +591,9 @@ export class OseActor extends Actor {
 
   _calculateMovement() {
     const data = this.data.data;
-    let option = game.settings.get("ose", "encumbranceOption");
-    let weight = data.encumbrance.value;
-    let delta = data.encumbrance.max - 1600;
+    const option = game.settings.get("ose", "encumbranceOption");
+    const weight = data.encumbrance.value;
+    const delta = data.encumbrance.max - 1600;
     if (["detailed", "complete"].includes(option)) {
       if (weight > data.encumbrance.max) {
         data.movement.base = 0;
@@ -610,9 +610,9 @@ export class OseActor extends Actor {
       const armors = this.data.items.filter((i) => i.type === "armor");
       let heaviest = 0;
       armors.forEach((a) => {
-        let armorData = a.data.data;
-        let weight = armorData.type;
-        let equipped = armorData.equipped;
+        const armorData = a.data.data;
+        const weight = armorData.type;
+        const equipped = armorData.equipped;
         if (equipped) {
           if (weight === "light" && heaviest === 0) {
             heaviest = 1;

--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -632,7 +632,9 @@ export class OseActor extends Actor {
           data.movement.base = 60;
           break;
       }
-      if (weight >= game.settings.get("ose", "significantTreasure")) {
+      if (weight >= data.encumbrance.max) {
+        data.movement.base = 0;
+      } else if (weight >= game.settings.get("ose", "significantTreasure")) {
         data.movement.base -= 30;
       }
     }


### PR DESCRIPTION
Taken from the original PR [here](https://gitlab.com/mesfoliesludiques/foundryvtt-ose/-/merge_requests/14)

This PR should cover bugs reported in issue #4:

For Basic encumbrance:

* Armor correctly reduces your movement speed
* Max encumbrance is based on the "Tweaks" value (1600 by default as per the rules), not based on the "Significant Treasure" option value
* Speed is correctly negated when at or above the max encumbrance
* the "Significant Treasure" value is shown as an encumbrance step (smalls arrows, like for Detailed Encumbrance)

For Detailed encumbrance:

* Adventuring Equipment is correctly detected: the "package" encumbrance of 80cn is 0 with no equipment, and 80 with any kind of gear (that is not: Armor, Weapon, Container or Treasure).

For all

* Speed reduction weight brackets include the carried weight threshold
