### PR TITLE
fix: removed event listener causing #20

### DIFF
--- a/dist/module/actor/character-sheet.js
+++ b/dist/module/actor/character-sheet.js
@@ -220,9 +220,10 @@ export class OseActorSheetCharacter extends OseActorSheet {
   activateListeners(html) {
     super.activateListeners(html);
 
-    html.find(".item-square").hover((event) => {
-      this._onShowItemTooltip(event);
-    });
+    // See Issue #20 Hovering over items inside a container causes the right sidebar to move
+    // html.find(".item-square").hover((event) => {
+    //   this._onShowItemTooltip(event);
+    // });
 
     html.find(".ability-score .attribute-name a").click((ev) => {
       let actorObject = this.actor;

--- a/src/module/actor/character-sheet.js
+++ b/src/module/actor/character-sheet.js
@@ -220,9 +220,10 @@ export class OseActorSheetCharacter extends OseActorSheet {
   activateListeners(html) {
     super.activateListeners(html);
 
-    html.find(".item-square").hover((event) => {
-      this._onShowItemTooltip(event);
-    });
+    // See Issue #20 Hovering over items inside a container causes the right sidebar to move
+    // html.find(".item-square").hover((event) => {
+    //   this._onShowItemTooltip(event);
+    // });
 
     html.find(".ability-score .attribute-name a").click((ev) => {
       let actorObject = this.actor;


### PR DESCRIPTION
Since the implementation of the tooltip is so far from finished, I created a new enhancement request issue #21 for this feature.

The event listener is commented out with a note leading back to issue #20. The event listener itself isn't implemented incorrectly, but it calls a private function that is implemented incorrectly.