### PR TITLE
Prevent adding non-"character" actors to party

### DIFF
--- a/src/module/dialog/party-sheet.js
+++ b/src/module/dialog/party-sheet.js
@@ -51,6 +51,10 @@ export class OsePartySheet extends FormApplication {
   }
 
   async _addActorToParty(actor) {
+    if (actor.type !== "character") {
+      return;
+    }
+
     await actor.setFlag("ose", "party", true);
   }
 


### PR DESCRIPTION
The party display filters out non-"characters", but using the "party" could be useful outside of the party sheet, so non-characters (only monsters for now) actors cannot get in the party.

It's a non-issue, but it was bothering me when I woke up this morning :cold_sweat:.