### PR TITLE
Chat card damage change

### DIFF
--- a/dist/lang/en.json
+++ b/dist/lang/en.json
@@ -189,6 +189,10 @@
   "OSE.Setting.Languages": "Languages",
   "OSE.Setting.LanguagesHint": "Enter a comma separated list of languages",
   "OSE.Setting.EnableInventory": "Enable Inventory",
+  "OSE.Setting.applyDamageOption": "Apply Damage From Chat",
+  "OSE.Setting.applyDamageOptionHint": "Select Actor to Apply Damage To",
+  "OSE.Setting.damageSelected": "Selected",
+  "OSE.Setting.damageTarget": "Targeted",
 
   "OSE.items.Equip": "Equip",
   "OSE.items.Unequip": "Unequip",

--- a/dist/module/chat.js
+++ b/dist/module/chat.js
@@ -55,12 +55,19 @@ export const addChatMessageButtons = function(msg, html, data) {
  * @param {Number} multiplier   A damage multiplier to apply to the rolled damage.
  * @return {Promise}
  */
-function applyChatCardDamage(roll, multiplier) {
-  const amount = roll.find('.dice-total').last().text();
-  return Promise.all(canvas.tokens.controlled.map(t => {
-    const a = t.actor;
-    return a.applyDamage(amount, multiplier);
-  }));
+ function applyChatCardDamage(roll, multiplier) {
+  const amount = roll.find('.dice-total').last().text(); 
+  const dmgTgt = game.settings.get('ose', 'applyDamageOption');
+  if(dmgTgt === `targeted`){
+    game.user.targets.forEach(async t=>{
+      if(game.user.isGM) return await t.actor.applyDamage(amount, multiplier)
+    })
+  }
+  if(dmgTgt === `selected`){
+    canvas.tokens.controlled.forEach(async t=>{
+      if(game.user.isGM) return await t.actor.applyDamage(amount,multiplier)
+    })
+  }
 }
 
 /* -------------------------------------------- */

--- a/dist/module/settings.js
+++ b/dist/module/settings.js
@@ -82,4 +82,18 @@ export const registerSettings = function () {
     config: true,
     onChange: _ => window.location.reload()
   });
+
+  game.settings.register('ose', 'applyDamageOption', {
+    name: game.i18n.localize('OSE.Setting.applyDamageOption'),
+    hint: game.i18n.localize('OSE.Setting.applyDamageOptionHint'),
+    default: 'selected',
+    scope: 'world',
+    type: String,
+    config: true,
+    choices: {
+      selected: 'OSE.Setting.damageSelected',
+      targeted: 'OSE.Setting.damageTarget'
+    },
+    onChange: _ => window.location.reload()
+  });
 };


### PR DESCRIPTION
I have added a game setting to select which actor chat card damage is applied to.

The options are selected, and targeted. 

Selected behaves the same as the current default behavior, damaging the selected token/actor when applying damage from a chat card. 
Targeted applies damage to the targeted tokens/actors when applying damage from a chat card.