### PR TITLE
fix(styles): nowrap tabs on character sheet

### DIFF
--- a/dist/ose.css
+++ b/dist/ose.css
@@ -96,6 +96,10 @@
   border-top: none;
   height: 18px;
   z-index: -1;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: space-around;
 }
 .ose.sheet.actor .sheet-tabs .item {
   padding: 1px 10px 0;

--- a/src/scss/actor-base.scss
+++ b/src/scss/actor-base.scss
@@ -105,6 +105,10 @@
     border-top: none;
     height: 18px;
     z-index: -1;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: space-around;
     .item {
       padding: 1px 10px 0;
       margin-left: -5px;


### PR DESCRIPTION
Fixes #25 

This is purely a "naive" patch: I found the correct behavior in V9 to be suitable, so I copied a set of attributes to the correct CSS selector and confirmed that it worked in 0.8.9. I was unable to account for any differences in behavior, but this points to a necessary audit/refactor of the CSS (possibly when we start evaluating a character sheet overhaul).