### PR TITLE
Fix: improvised attack rolls issue

### DIFF
--- a/dist/module/actor/entity.js
+++ b/dist/module/actor/entity.js
@@ -480,7 +480,7 @@ export class OseActor extends Actor {
     const rollData = {
       actor: this.data,
       item: attData.item,
-      itemId: attData.item._id,
+      itemId: attData.item?._id,
       roll: {
         type: options.type,
         thac0: thac0,
@@ -497,7 +497,7 @@ export class OseActor extends Actor {
       skipDialog: options.skipDialog,
       speaker: ChatMessage.getSpeaker({ actor: this }),
       flavor: label,
-      flags: { ose: { roll: "attack", itemId: attData.item._id } },
+      flags: { ose: { roll: "attack", itemId: attData.item?._id } },
       title: label,
     });
   }

--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -480,7 +480,7 @@ export class OseActor extends Actor {
     const rollData = {
       actor: this.data,
       item: attData.item,
-      itemId: attData.item._id,
+      itemId: attData.item?._id,
       roll: {
         type: options.type,
         thac0: thac0,
@@ -497,7 +497,7 @@ export class OseActor extends Actor {
       skipDialog: options.skipDialog,
       speaker: ChatMessage.getSpeaker({ actor: this }),
       flavor: label,
-      flags: { ose: { roll: "attack", itemId: attData.item._id } },
+      flags: { ose: { roll: "attack", itemId: attData.item?._id } },
       title: label,
     });
   }


### PR DESCRIPTION
A bug reported on Discord noted that Clicking MEL or MIS (attributes tab) returns the following errors in OSE 1.3.3.

![image](https://user-images.githubusercontent.com/1410433/150692841-99842453-e9e5-4beb-b147-95a65dc52a4c.png)

I reproduced on 0.8.9 and V9. Since these buttons are primarily used for improvised attacks without a designated weapon, I deduced that a change we made to make Automated Animations work(#29), which requires some info about the Weapon being used, is now causing an error when not using a weapon ( _id not found). Optional chaining when getting the item id appears to fix the error