### PR TITLE
chat-card-damage

### DIFF
--- a/src/module/chat.js
+++ b/src/module/chat.js
@@ -55,12 +55,18 @@ export const addChatMessageButtons = function(msg, html, data) {
  * @param {Number} multiplier   A damage multiplier to apply to the rolled damage.
  * @return {Promise}
  */
-function applyChatCardDamage(roll, multiplier) {
-  const amount = roll.find('.dice-total').last().text();
-  return Promise.all(canvas.tokens.controlled.map(t => {
-    const a = t.actor;
-    return a.applyDamage(amount, multiplier);
-  }));
-}
+ function applyChatCardDamage(roll, multiplier) {
+  const amount = roll.find('.dice-total').last().text(); 
+  const dmgTgt = game.settings.get('ose', 'applyDamageOption');
+  if(dmgTgt === `targeted`){
+    game.user.targets.forEach(async t=>{
+      if(game.user.isGM) return await t.actor.applyDamage(amount, multiplier)
+    })
+  }
+  if(dmgTgt === `selected`){
+    canvas.tokens.controlled.forEach(async t=>{
+      if(game.user.isGM) return await t.actor.applyDamage(amount,multiplier)
+    })
+  }
 
 /* -------------------------------------------- */

--- a/src/module/settings.js
+++ b/src/module/settings.js
@@ -82,4 +82,17 @@ export const registerSettings = function () {
     config: true,
     onChange: _ => window.location.reload()
   });
+   game.settings.register('ose', 'applyDamageOption', {
+    name: game.i18n.localize('OSE.Setting.applyDamageOption'),
+    hint: game.i18n.localize('OSE.Setting.applyDamageOptionHint'),
+    default: 'selected',
+    scope: 'world',
+    type: String,
+    config: true,
+    choices: {
+      selected: 'OSE.Setting.damageSelected',
+      targeted: 'OSE.Setting.damageTarget'
+    },
+    onChange: _ => window.location.reload()
+  });
 };


### PR DESCRIPTION
Adds a setting allowing gm to select the target of damage applied via chat message roll result.
Selecting 'targeted' applies damage to the targeted token  actors. 
Selecting 'selected' applies damage to the selected token actors