### PR TITLE
Added 5 contributors' names to AUTHORS and CONTRIBUTORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,7 +9,12 @@
 # Please keep the list sorted.
 
 Emmanuel Ruaud <43685820+mesfoliesludiques@users.noreply.github.com>
+Ian Engleback <35422051+engleback@users.noreply.github.com>
+IGALEGOI <97805442+IGALEGOI@users.noreply.github.com>
+RabidOwlbear <71675732+RabidOwlbear@users.noreply.github.com>
+Stephen Faure <faure.stephen@gmail.com>
 VTT Red LLC <ose@vtt.red>
+WallaceMcGregor <17795541+WallaceMcGregor@users.noreply.github.com>
 
 # PLEASE NOTE THIS LIST IS INCOMPLETE
 # AND WAITING FOR CONTRIBUTORS TO RESPOND TO AN OPEN ISSUE

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,6 +15,11 @@
 
 Anthony Ronda <ose.vtt.red@anthonyronda.com>
 Emmanuel Ruaud <43685820+mesfoliesludiques@users.noreply.github.com>
+Ian Engleback <35422051+engleback@users.noreply.github.com>
+IGALEGOI <97805442+IGALEGOI@users.noreply.github.com>
+RabidOwlbear <71675732+RabidOwlbear@users.noreply.github.com>
+Stephen Faure <faure.stephen@gmail.com>
+WallaceMcGregor <17795541+WallaceMcGregor@users.noreply.github.com>
 
 # PLEASE NOTE THIS LIST IS INCOMPLETE
 # AND WAITING FOR CONTRIBUTORS TO RESPOND TO AN OPEN ISSUE


### PR DESCRIPTION
Thanks to all you lovely contributors! Since this is the first PR with contributors names being added, I should explain both files quickly

CONTRIBUTORS: these are individuals' names, no matter who owns the copyright to a given contribution we're interested in officially recognizing the names of contributors!
AUTHORS: this is a list of copyright owners of code or translations in the system. Remember that even though we've released our contributions under an open source license, we all retain copyright to our contributions. If, for example, an employee of Necrotic Gnome were to make a contribution to the code for their job, Necrotic Gnome owns the copyright, not the employee.