### PR TITLE
Display containers as categories for ease of use + Inventory HTML/JS refactor

### DIFF
--- a/src/module/actor/actor-sheet.js
+++ b/src/module/actor/actor-sheet.js
@@ -31,25 +31,15 @@ export class OseActorSheet extends ActorSheet {
     super.activateEditor(name, options, initialContent);
   }
 
-  _onItemSummary(event) {
+  _toggleItemSummary(event) {
     event.preventDefault();
-    let li = $(event.currentTarget).parents(".item"),
-      item = this.actor.items.get(li.data("item-id")),
-      description = TextEditor.enrichHTML(item.data.data.description);
+    const summary = $(event.currentTarget).closest(".item-header").next(".item-summary");
 
-    // Toggle summary
-    if (li.hasClass("expanded")) {
-      let summary = li.parents(".item-entry").children(".item-summary");
-      summary.slideUp(200, () => summary.remove());
+    if (summary.css("display") === "none") {
+      summary.slideDown(200);
     } else {
-      // Add item tags
-      let div = $(
-        `<div class="item-summary"><ol class="tag-list">${item.getTags()}</ol><div>${description}</div></div>`
-      );
-      li.parents(".item-entry").append(div.hide());
-      div.slideDown(200);
+      summary.slideUp(200);
     }
-    li.toggleClass("expanded");
   }
 
   async _onSpellChange(event) {
@@ -83,9 +73,7 @@ export class OseActorSheet extends ActorSheet {
     super.activateListeners(html);
 
     // Item summaries
-    html
-      .find(".item .item-name h4")
-      .click((event) => this._onItemSummary(event));
+    html.find(".item-name").click((event) => { this._toggleItemSummary(event) });
 
     html.find(".item .item-controls .item-show").click(async (ev) => {
       const li = $(ev.currentTarget).parents(".item");
@@ -174,7 +162,7 @@ export class OseActorSheet extends ActorSheet {
     const dropTarget = event.target.closest("[data-item-id]");
     const targetId = dropTarget ? dropTarget.dataset.itemId : null;
     const target = siblings.find(s => s.data._id === targetId);
-    
+
     if (target?.data.type == "container") {
       this.actor.updateEmbeddedDocuments("Item", [
         { _id: source.id, "data.containerId": target.id }

--- a/src/module/actor/actor-sheet.js
+++ b/src/module/actor/actor-sheet.js
@@ -83,21 +83,16 @@ export class OseActorSheet extends ActorSheet {
     const item = this._getItemFromActor(event);
     const itemDisplay = event.currentTarget.closest(".item-entry");
 
-    if (item.type === "container") {
-      const updateData = item.data.data.itemIds.reduce((acc, val) => {
-        acc.push({
-          _id: val.id,
-          "data.containerId": "",
-        });
+    if (item.type === "container" && item.data.data.itemIds) {
+      const containedItems = item.data.data.itemIds;
+      const updateData = containedItems.reduce((acc, val) => {
+        acc.push({ _id: val.id, "data.containerId": "", });
         return acc;
       }, []);
-      this.actor.updateEmbeddedDocuments("Item", updateData).then(() => {
-        this.actor.deleteEmbeddedDocuments("Item", [itemDisplay.dataset.itemId]);
-      });
-    } else {
-      this.actor.deleteEmbeddedDocuments("Item", [itemDisplay.dataset.itemId]);
-      $(itemDisplay).slideUp(200, () => this.render(false));
+
+      await this.actor.updateEmbeddedDocuments("Item", updateData);
     }
+    this.actor.deleteEmbeddedDocuments("Item", [itemDisplay.dataset.itemId]);
   }
 
   /**

--- a/src/module/item/item-sheet.js
+++ b/src/module/item/item-sheet.js
@@ -61,12 +61,12 @@ export class OseItemSheet extends ItemSheet {
       if (ev.which == 13) {
         let value = $(ev.currentTarget).val();
         let values = value.split(",");
-        this.object.pushTag(values);
+        this.object.pushManualTag(values);
       }
     });
     html.find(".tag-delete").click((ev) => {
       let value = ev.currentTarget.parentElement.dataset.tag;
-      this.object.popTag(value);
+      this.object.popManualTag(value);
     });
     html.find("a.melee-toggle").click(() => {
       this.object.update({ data: { melee: !this.object.data.data.melee } });

--- a/src/module/preloadTemplates.js
+++ b/src/module/preloadTemplates.js
@@ -3,17 +3,21 @@ export const preloadHandlebarsTemplates = async function () {
     //Character Sheets
     "systems/ose/dist/templates/actors/character-sheet.html",
     "systems/ose/dist/templates/actors/monster-sheet.html",
-    //Actor partials
-    //Sheet tabs
+
+    //Character Sheets Partials
     "systems/ose/dist/templates/actors/partials/character-header.html",
     "systems/ose/dist/templates/actors/partials/character-attributes-tab.html",
     "systems/ose/dist/templates/actors/partials/character-abilities-tab.html",
     "systems/ose/dist/templates/actors/partials/character-spells-tab.html",
     "systems/ose/dist/templates/actors/partials/character-inventory-tab.html",
+    "systems/ose/dist/templates/actors/partials/actor-item-summary.html",
     "systems/ose/dist/templates/actors/partials/character-notes-tab.html",
-
     "systems/ose/dist/templates/actors/partials/monster-header.html",
     "systems/ose/dist/templates/actors/partials/monster-attributes-tab.html",
+
+    // Party Sheet
+    "systems/ose/dist/templates/apps/party-sheet.html",
+    "systems/ose/dist/templates/apps/party-xp.html",
   ];
   return loadTemplates(templatePaths);
 };

--- a/src/module/renderList.js
+++ b/src/module/renderList.js
@@ -9,7 +9,7 @@ export const RenderCompendium = async function (object, html, d) {
     const element = docs.filter((d) => d.id === id)[0];
     const tagList = document.createElement("ol");
     tagList.classList.add("tag-list");
-    const tags = element.getTags();
+    const tags = element.getAutoTagDisplay();
     tagList.innerHTML = tags;
     item.appendChild(tagList);
   });
@@ -27,7 +27,7 @@ export const RenderDirectory = async function (object, html) {
     const foundryDocument = content.find(
       (e) => e.id == item.dataset.documentId
     );
-    const tags = foundryDocument.getTags();
+    const tags = foundryDocument.getAutoTagDisplay();
     tagList.innerHTML = tags;
     item.appendChild(tagList);
   });

--- a/src/scss/actor-base.scss
+++ b/src/scss/actor-base.scss
@@ -241,6 +241,9 @@
           box-shadow: inset 1px 0 0 0 $colorTan;
         }
         .item-summary {
+          display: none
+        }
+        .item-description {
           font-size: 13px;
           padding: 0 4px;
           line-height: 20px;

--- a/src/scss/actor-base.scss
+++ b/src/scss/actor-base.scss
@@ -30,7 +30,7 @@
       background: $darkBackground;
       line-height: 12px;
       height: 20px;
-      text-align: center;
+      text-align: left;
       margin: 0;
       padding: 4px;
       display: flex;
@@ -212,34 +212,35 @@
       .header-spells {
         line-height: 30px;
       }
-      .item-titles {
+      .item-category-title {
         text-align: center;
         padding: 4px 0;
         border: 1px solid $colorDark;
         box-shadow: 0 0 5px $colorDark;
-        .item-name {
-          text-align: left;
-          text-indent: 8px;
-        }
+        line-height: 16px;
         font-weight: 300;
         font-size: 13px;
         background: $darkBackground;
         color: white;
+        cursor: pointer;
         input {
           color: white;
           margin: auto;
+        }
+        .category-name {
+          text-indent: 8px;
+          text-align: left;
+          overflow: hidden;
+          margin: 0;
+          height: 16px;
+          flex-basis: 90px;
         }
       }
       .item-list {
         list-style: none;
         margin: 0;
         padding: 0;
-        & > * {
-          line-height: 30px;
-        }
-        .item-entry {
-          box-shadow: inset 1px 0 0 0 $colorTan;
-        }
+
         .item-summary {
           display: none
         }
@@ -274,59 +275,33 @@
           @extend %header-field !optional;
           padding: 0px;
           margin-bottom: 0px;
+          height: 30px;
+
+          .item-image {
+            flex-basis: 30px;
+            flex-grow: 0;
+            background-size: contain;
+            background-repeat: no-repeat;
+          }
+
+          .item-name {
+            text-indent: 8px;
+            text-align: left;
+            overflow: hidden;
+            margin: 0;
+            line-height: 30px;
+            flex-basis: 90px;
+            cursor: pointer;
+          }
         }
         .item-entry {
+          box-shadow: inset 1px 0 0 0 $colorTan;
+          line-height: 30px;
           &:nth-child(even) {
-            .item {
+            .item-header {
               background: rgba(0, 0, 0, 0.1);
             }
           }
-          .item-gallery {
-            display: flex;
-            margin-left: 36px;
-            margin-bottom: 2px;
-            overflow-x: auto;
-            .item-entry {
-              &:nth-child(even) .item {
-                background: none;
-              }
-              padding: 0 1px;
-              box-shadow: none;
-              .item-square {
-                box-shadow: 0 0 1px $colorFaint;
-                height: 28px;
-                width: 28px;
-                cursor: pointer;
-                position: relative;
-                &:hover {
-                  box-shadow: 0 0 1px $colorCrimson;
-                  border: 1px solid red;
-                  box-sizing: border-box;
-                }
-                .item-image {
-                  height: 28px;
-                  width: 28px;
-                  background-size: 28px 28px;
-                  background-position: center;
-                }
-                .item-quantity {
-                  position: absolute;
-                  top: 6px;
-                  right: 1px;
-                  text-shadow: 0 0 2px black;
-                  font-size: 12px;
-                  font-weight: 600;
-                  color: white;
-                  pointer-events: none;
-                }
-              }
-            }
-          }
-        }
-        .item {
-          line-height: 30px;
-          height: 30px;
-          overflow: hidden;
         }
         .item-equipped {
           grid-area: item-equipped;
@@ -341,24 +316,7 @@
             background-image: url("/icons/svg/d20-black.svg") !important;
           }
         }
-        .item-name {
-          text-indent: 8px;
-          text-align: left;
-          overflow: hidden;
-          height: 30px;
-          margin: 0;
-          line-height: 30px;
-          flex-basis: 90px;
-          .item-image {
-            flex-basis: 30px;
-            flex-grow: 0;
-            background-size: contain;
-            background-repeat: no-repeat;
-          }
-          h4 {
-            margin: 0;
-          }
-        }
+
         .consumable-counter {
           height: 14px;
           display: flex;
@@ -432,7 +390,7 @@
           }
         }
       }
-      .item-caret {
+      .category-caret {
         flex: 0 0 10px;
         margin: 0 4px;
         cursor: pointer;
@@ -453,7 +411,7 @@
         }
       }
       &.spells {
-        .item-titles {
+        .item-category-title {
           line-height: 24px;
         }
         .item-controls {

--- a/src/scss/character.scss
+++ b/src/scss/character.scss
@@ -69,7 +69,7 @@
         .languages {
           margin: 2px;
           flex: 0 0 130px;
-          .item-titles {
+          .item-category-title {
             .item-controls {
               flex: 0 0 20px;
             }

--- a/src/scss/monster.scss
+++ b/src/scss/monster.scss
@@ -85,19 +85,40 @@
     .attack-pattern {
       // border-bottom: 1px solid $colorDark;
       box-shadow: 1px 0 1px black;
-    }
-    .item-list {
-      .item-entry {
-        .item-pattern {
-          flex: 0 15px;
-          font-size: 10px;
-          text-align: center;
-          cursor: pointer;
-          &:hover .fas {
-            transform: rotate(90deg);
-          }
+      padding: 0;
+      margin: 0 0 0.5em;
+
+      .pattern-green {
+        background-color: green;
+      }
+      .pattern-red {
+        background-color: red;
+      }
+      .pattern-yellow {
+        background-color: yellow;
+      }
+      .pattern-purple {
+        background-color: purple;
+      }
+      .pattern-blue {
+        background-color: blue;
+      }
+      .pattern-orange {
+        background-color: orange;
+      }
+      .pattern-white {
+        background-color: white;
+      }
+
+      .item-pattern {
+        flex: 0 15px;
+        font-size: 10px;
+        text-align: center;
+        cursor: pointer;
+        &:hover .fas {
+          transform: rotate(90deg);
         }
-      }  
+      }
     }
   }
 }

--- a/src/templates/actors/monster-sheet.html
+++ b/src/templates/actors/monster-sheet.html
@@ -38,7 +38,7 @@
     {{/if}}
     <div class="tab" data-group="primary" data-tab="notes">
       <div class="inventory">
-        <div class="item-titles">{{localize "OSE.category.notes"}}</div>
+        <div class="item-category-title">{{localize "OSE.category.notes"}}</div>
         <div class="resizable-editor" data-editor-size="320">
           {{editor content=data.details.biography
           target="data.details.biography" button=true owner=owner

--- a/src/templates/actors/partials/actor-item-summary.html
+++ b/src/templates/actors/partials/actor-item-summary.html
@@ -1,0 +1,15 @@
+<div class="item-description">
+  <ol class="tag-list">
+    {{#each item.data.data.autoTags as |tag|}}
+    {{#if tag.label}}
+    <li class="tag">
+      {{#if tag.icon}}
+      <i class="fas {{tag.icon}}"></i>
+      {{/if}}
+      {{tag.label~}}
+    </li>
+    {{/if}}
+    {{/each}}
+  </ol>
+  <div>{{{item.data.data.description}}}</div>
+</div>

--- a/src/templates/actors/partials/character-abilities-tab.html
+++ b/src/templates/actors/partials/character-abilities-tab.html
@@ -40,7 +40,7 @@
   <ol class="item-list resizable" data-base-size="260">
     {{#each abilities as |item|}}
     <li class="item-entry">
-      <div class="item flexrow" data-item-id="{{item.id}}">
+      <div class="item item-header flexrow" data-item-id="{{item.id}}">
         <div class="item-name {{#if item.data.data.roll}}item-rollable{{/if}} flexrow">
           <div class="item-image" style="background-image: url({{item.img}})"></div>
           <a>
@@ -56,6 +56,9 @@
           <a class="item-control item-delete" title='{{localize "OSE.Delete"}}'><i class="fas fa-trash"></i></a>
           {{/if}}
         </div>
+      </div>
+      <div class="item-summary">
+        {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=item}}
       </div>
     </li>
     {{/each}}

--- a/src/templates/actors/partials/character-abilities-tab.html
+++ b/src/templates/actors/partials/character-abilities-tab.html
@@ -1,35 +1,47 @@
 <ul class="attributes exploration flexrow">
   <li class="attribute flexrow" data-exploration="ld">
-    <h4 class="attribute-name box-title" title="({{localize 'OSE.exploration.ld.abrev'}}) {{localize 'OSE.exploration.ld.long'}}"><a>{{ localize "OSE.exploration.ld.short" }}</a></h4>
+    <h4 class="attribute-name box-title"
+      title="({{localize 'OSE.exploration.ld.abrev'}}) {{localize 'OSE.exploration.ld.long'}}"><a>{{ localize
+        "OSE.exploration.ld.short" }}</a></h4>
     <div class="attribute-value">
-      <input name="data.exploration.ld" type="text" value="{{data.exploration.ld}}" data-dtype="Number" placeholder="0" />
+      <input name="data.exploration.ld" type="text" value="{{data.exploration.ld}}" data-dtype="Number"
+        placeholder="0" />
     </div>
   </li>
   <li class="attribute flexrow" data-exploration="od">
-    <h4 class="attribute-name box-title" title="({{localize 'OSE.exploration.od.abrev'}}) {{localize 'OSE.exploration.od.long'}}"><a>{{ localize "OSE.exploration.od.short" }}</a>
+    <h4 class="attribute-name box-title"
+      title="({{localize 'OSE.exploration.od.abrev'}}) {{localize 'OSE.exploration.od.long'}}"><a>{{ localize
+        "OSE.exploration.od.short" }}</a>
     </h4>
     <div class="attribute-value">
-      <input name="data.exploration.od" type="text" value="{{data.exploration.od}}" placeholder="0" data-dtype="String" />
+      <input name="data.exploration.od" type="text" value="{{data.exploration.od}}" placeholder="0"
+        data-dtype="String" />
     </div>
   </li>
   <li class="attribute flexrow" data-exploration="sd">
-    <h4 class="attribute-name box-title" title="({{localize 'OSE.exploration.sd.abrev'}}) {{localize 'OSE.exploration.sd.long'}}"><a>{{ localize "OSE.exploration.sd.short" }}</a>
+    <h4 class="attribute-name box-title"
+      title="({{localize 'OSE.exploration.sd.abrev'}}) {{localize 'OSE.exploration.sd.long'}}"><a>{{ localize
+        "OSE.exploration.sd.short" }}</a>
     </h4>
     <div class="attribute-value">
-      <input name="data.exploration.sd" type="text" value="{{data.exploration.sd}}" placeholder="0" data-dtype="String" />
+      <input name="data.exploration.sd" type="text" value="{{data.exploration.sd}}" placeholder="0"
+        data-dtype="String" />
     </div>
   </li>
   <li class="attribute flexrow" data-exploration="ft">
-    <h4 class="attribute-name box-title" title="({{localize 'OSE.exploration.ft.abrev'}}) {{localize 'OSE.exploration.ft.long'}}"><a>{{ localize "OSE.exploration.ft.short" }}</a>
+    <h4 class="attribute-name box-title"
+      title="({{localize 'OSE.exploration.ft.abrev'}}) {{localize 'OSE.exploration.ft.long'}}"><a>{{ localize
+        "OSE.exploration.ft.short" }}</a>
     </h4>
     <div class="attribute-value">
-      <input name="data.exploration.ft" type="text" value="{{data.exploration.ft}}" placeholder="0" data-dtype="String" />
+      <input name="data.exploration.ft" type="text" value="{{data.exploration.ft}}" placeholder="0"
+        data-dtype="String" />
     </div>
   </li>
 </ul>
 <div class="inventory abilities">
-  <div class="item-titles flexrow">
-    <div class="item-name">{{localize 'OSE.category.abilities'}}</div>
+  <div class="item-category-title flexrow">
+    <div class="category-name">{{localize 'OSE.category.abilities'}}</div>
     <div class="item-controls">
       {{#if owner}}
       <a class="item-control item-create" title='{{localize "OSE.Add"}}' data-type="ability"><i
@@ -39,16 +51,12 @@
   </div>
   <ol class="item-list resizable" data-base-size="260">
     {{#each abilities as |item|}}
-    <li class="item-entry">
-      <div class="item item-header flexrow" data-item-id="{{item.id}}">
-        <div class="item-name {{#if item.data.data.roll}}item-rollable{{/if}} flexrow">
-          <div class="item-image" style="background-image: url({{item.img}})"></div>
-          <a>
-            <h4 title="{{item.name}}">
-              {{item.name~}}
-            </h4>
-          </a>
-        </div>
+    <li class="item-entry" data-item-id="{{item.id}}">
+      <div class="item-header flexrow {{#if item.data.data.roll}}item-rollable{{/if}}">
+        <div class="item-image" style="background-image: url({{item.img}})"></div>
+        <h4 class="item-name" title="{{item.name}}">
+          {{item.name~}}
+        </h4>
         <div class="item-controls">
           {{#if ../owner}}
           <a class="item-control item-show" title='{{localize "OSE.Show"}}'><i class="fas fa-eye"></i></a>

--- a/src/templates/actors/partials/character-inventory-tab.html
+++ b/src/templates/actors/partials/character-inventory-tab.html
@@ -13,7 +13,7 @@
     <ol class="item-list">
       {{#each owned.weapons as |item|}}
       <li class="item-entry">
-        <div class="item flexrow" data-item-id="{{item.id}}">
+        <div class="item item-header flexrow" data-item-id="{{item.id}}">
           <div class="item-name item-rollable flexrow">
             <div class="item-image" style="background-image: url({{item.img}})"></div>
             <a>
@@ -49,6 +49,9 @@
             {{/if}}
           </div>
         </div>
+        <div class="item-summary">
+          {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=item}}
+        </div>
       </li>
       {{/each}}
     </ol>
@@ -71,7 +74,7 @@
     <ol class="item-list">
       {{#each owned.armors as |item|}}
       <li class="item-entry">
-        <div class="item flexrow" data-item-id="{{item.id}}">
+        <div class="item item-header flexrow" data-item-id="{{item.id}}">
           <div class="item-name flexrow">
             <div class="item-image" style="background-image: url({{item.img}})"></div>
             <a>
@@ -101,6 +104,9 @@
             {{/if}}
           </div>
         </div>
+        <div class="item-summary">
+          {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=item}}
+        </div>
       </li>
       {{/each}}
     </ol>
@@ -120,7 +126,7 @@
     <ol class="item-list">
       {{#each owned.containers as |bag|}}
       <li class="item-entry container">
-        <div class="item flexrow" data-item-id="{{bag.id}}">
+        <div class="item item-header flexrow" data-item-id="{{bag.id}}">
           <div class="item-name flexrow">
             <div class="item-image" style="background-image: url({{bag.img}})"></div>
             <a>
@@ -143,6 +149,9 @@
             <a class="item-control item-delete" title='{{localize "OSE.Delete"}}'><i class="fas fa-trash"></i></a>
             {{/if}}
           </div>
+        </div>
+        <div class="item-summary">
+          {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=item}}
         </div>
         <div class="item-gallery">
           {{#each bag.data.data.itemIds as |item|}}
@@ -175,7 +184,7 @@
     <ol class="item-list">
       {{#each owned.items as |item|}}
       <li class="item-entry">
-        <div class="item flexrow" data-item-id="{{item.id}}">
+        <div class="item item-header flexrow" data-item-id="{{item.id}}">
           <div class="item-name flexrow">
             <div class="item-image" style="background-image: url({{item.img}})"></div>
             <a>
@@ -209,6 +218,9 @@
         </div>
         {{/if}}
         {{/if}}
+        <div class="item-summary">
+          {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=item}}
+        </div>
       </li>
       {{/each}}
     </ol>
@@ -229,7 +241,7 @@
     <ol class="item-list">
       {{#each owned.treasures as |item|}}
       <li class="item-entry">
-        <div class="item flexrow" data-item-id="{{item.id}}">
+        <div class="item item-header flexrow" data-item-id="{{item.id}}">
           <div class="item-name flexrow">
             <div class="item-image" style="background-image: url({{item.img}})"></div>
             <a>
@@ -252,6 +264,9 @@
             <a class="item-control item-delete" title='{{localize "OSE.Delete"}}'><i class="fas fa-trash"></i></a>
             {{/if}}
           </div>
+        </div>
+        <div class="item-summary">
+          {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=item}}
         </div>
       </li>
       {{/each}}

--- a/src/templates/actors/partials/character-inventory-tab.html
+++ b/src/templates/actors/partials/character-inventory-tab.html
@@ -23,12 +23,12 @@
             </a>
           </div>
           <div class="icon-row flexrow">
-            {{#each item.data.data.tags as |tag|}}
+            {{#each item.data.data.manualTags as |tag|}}
             {{#if (getTagIcon tag.value)}}
             <img title="{{tag.title}}" src="{{getTagIcon tag.value}}" width="24" height="24" />
             {{/if}}
             {{/each}}
-            {{#each item.data.data.tags as |tag|}}
+            {{#each item.data.data.manualTags as |tag|}}
             {{#unless (getTagIcon tag.value)}}
             <span title="{{tag.title}}">{{tag.value}}{{#unless @last}},{{/unless}}</span>
 

--- a/src/templates/actors/partials/character-inventory-tab.html
+++ b/src/templates/actors/partials/character-inventory-tab.html
@@ -1,277 +1,286 @@
 <section class="inventory resizable" data-base-size="310">
-  <div>
-    <li class="item-titles flexrow">
-      <div class="item-caret"><i class="fas fa-caret-down"></i></div>
-      <div class="item-name">{{localize "OSE.items.Weapons"}}</div>
-      <div class="icon-row">{{localize "OSE.items.Qualities"}}</div>
-      <div class="field-short"><i class="fas fa-weight-hanging"></i></div>
-      <div class="item-controls">
-        <a class="item-control item-create" data-type="weapon" title="{{localize 'OSE.Add'}}"><i
-            class="fa fa-plus"></i></a>
-      </div>
-    </li>
-    <ol class="item-list">
-      {{#each owned.weapons as |item|}}
-      <li class="item-entry">
-        <div class="item item-header flexrow" data-item-id="{{item.id}}">
-          <div class="item-name item-rollable flexrow">
-            <div class="item-image" style="background-image: url({{item.img}})"></div>
-            <a>
-              <h4 title="{{item.name}}">
-                {{item.name~}}
-              </h4>
-            </a>
-          </div>
-          <div class="icon-row flexrow">
-            {{#each item.data.data.manualTags as |tag|}}
-            {{#if (getTagIcon tag.value)}}
-            <img title="{{tag.title}}" src="{{getTagIcon tag.value}}" width="24" height="24" />
-            {{/if}}
-            {{/each}}
-            {{#each item.data.data.manualTags as |tag|}}
-            {{#unless (getTagIcon tag.value)}}
-            <span title="{{tag.title}}">{{tag.value}}{{#unless @last}},{{/unless}}</span>
+  <div id="weapons" class="item-category-title flexrow">
+    <div class="category-caret"><i class="fas fa-caret-down"></i></div>
+    <div class="category-name">{{localize "OSE.items.Weapons"}}</div>
+    <div class="icon-row">{{localize "OSE.items.Qualities"}}</div>
+    <div class="field-short"><i class="fas fa-weight-hanging"></i></div>
+    <div class="item-controls">
+      <a class="item-control item-create" data-type="weapon" title="{{localize 'OSE.Add'}}"><i
+          class="fa fa-plus"></i></a>
+    </div>
+  </div>
+  <ol class="item-list">
+    {{#each owned.weapons as |item|}}
+    <li class="item-entry item" data-item-id="{{item.id}}">
+      <div class="item-header flexrow">
+        <div class="item-image" style="background-image: url({{item.img}})"></div>
+        <h4 class="item-name" title="{{item.name}}">
+          {{item.name~}}
+        </h4>
+        <div class="icon-row flexrow">
+          {{#each item.data.data.manualTags as |tag|}}
+          {{#if (getTagIcon tag.value)}}
+          <img title="{{tag.title}}" src="{{getTagIcon tag.value}}" width="24" height="24" />
+          {{/if}}
+          {{/each}}
+          {{#each item.data.data.manualTags as |tag|}}
+          {{#unless (getTagIcon tag.value)}}
+          <span title="{{tag.title}}">{{tag.value}}{{#unless @last}},{{/unless}}</span>
 
-            {{/unless}}
-            {{/each}}
-          </div>
-          <div class="field-short">
-            {{#if (eq @root.config.encumbrance "basic")}}_{{else}}{{item.data.data.weight}}{{/if}}
-          </div>
-          <div class="item-controls">
-            {{#if @root.owner}}
-            <a class="item-control item-toggle {{#unless item.data.data.equipped}}item-unequipped{{/unless}}"
-              title='{{localize "OSE.items.Equip"}}'>
-              <i class="fas fa-tshirt"></i>
-            </a>
-            <a class="item-control item-edit" title='{{localize "OSE.Edit"}}'><i class="fas fa-edit"></i></a>
-            <a class="item-control item-delete" title='{{localize "OSE.Delete"}}'><i class="fas fa-trash"></i></a>
-            {{/if}}
-          </div>
+          {{/unless}}
+          {{/each}}
         </div>
-        <div class="item-summary">
-          {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=item}}
+        <div class="field-short">
+          {{#if (eq @root.config.encumbrance "basic")}}_{{else}}{{item.data.data.weight}}{{/if}}
         </div>
-      </li>
-      {{/each}}
-    </ol>
-  </div>
-  <div>
-    <li class="item-titles flexrow">
-      <div class="item-caret"><i class="fas fa-caret-down"></i></div>
-      <div class="item-name">{{localize "OSE.items.Armors"}}</div>
-      {{#if @root.config.ascendingAC}}
-      <div class="field-short">{{localize "OSE.items.ArmorAAC"}}</div>
-      {{else}}
-      <div class="field-short">{{localize "OSE.items.ArmorAC"}}</div>
-      {{/if}}
-      <div class="field-short"><i class="fas fa-weight-hanging"></i></div>
-      <div class="item-controls">
-        <a class="item-control item-create" data-type="armor" title="{{localize 'OSE.Add'}}"><i
-            class="fa fa-plus"></i></a>
+        <div class="item-controls">
+          {{#if @root.owner}}
+          <a class="item-control item-toggle {{#unless item.data.data.equipped}}item-unequipped{{/unless}}"
+            title='{{localize "OSE.items.Equip"}}'>
+            <i class="fas fa-tshirt"></i>
+          </a>
+          <a class="item-control item-edit" title='{{localize "OSE.Edit"}}'><i class="fas fa-edit"></i></a>
+          <a class="item-control item-delete" title='{{localize "OSE.Delete"}}'><i class="fas fa-trash"></i></a>
+          {{/if}}
+        </div>
+      </div>
+      <div class="item-summary">
+        {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=item}}
       </div>
     </li>
-    <ol class="item-list">
-      {{#each owned.armors as |item|}}
-      <li class="item-entry">
-        <div class="item item-header flexrow" data-item-id="{{item.id}}">
-          <div class="item-name flexrow">
+    {{/each}}
+  </ol>
+  <div id="armors" class="item-category-title flexrow">
+    <div class="category-caret"><i class="fas fa-caret-down"></i></div>
+    <div class="category-name">{{localize "OSE.items.Armors"}}</div>
+    {{#if @root.config.ascendingAC}}
+    <div class="field-short">{{localize "OSE.items.ArmorAAC"}}</div>
+    {{else}}
+    <div class="field-short">{{localize "OSE.items.ArmorAC"}}</div>
+    {{/if}}
+    <div class="field-short"><i class="fas fa-weight-hanging"></i></div>
+    <div class="item-controls">
+      <a class="item-control item-create" data-type="armor" title="{{localize 'OSE.Add'}}"><i
+          class="fa fa-plus"></i></a>
+    </div>
+  </div>
+  <ol class="item-list">
+    {{#each owned.armors as |item|}}
+    <li class="item-entry item" data-item-id="{{item.id}}">
+      <div class="item-header flexrow">
+        <div class="item-image" style="background-image: url({{item.img}})"></div>
+        <h4 class="item-name" title="{{item.name}}">
+          {{item.name~}}
+        </h4>
+        <div class="field-short">
+          {{#if @root.config.ascendingAC}}
+          {{item.data.data.aac.value}}
+          {{else}}
+          {{item.data.data.ac.value}}
+          {{/if}}
+        </div>
+        <div class="field-short">
+          {{#if (eq @root.config.encumbrance "basic")}}_{{else}}{{item.data.data.weight}}{{/if}}
+        </div>
+        <div class="item-controls">
+          {{#if @root.owner}}
+          <a class="item-control item-toggle {{#unless item.data.data.equipped}}item-unequipped{{/unless}}"
+            title='{{localize "OSE.items.Equip"}}'>
+            <i class="fas fa-tshirt"></i>
+          </a>
+          <a class="item-control item-edit" title='{{localize "OSE.Edit"}}'><i class="fas fa-edit"></i></a>
+          <a class="item-control item-delete" title='{{localize "OSE.Delete"}}'><i class="fas fa-trash"></i></a>
+          {{/if}}
+        </div>
+      </div>
+      <div class="item-summary">
+        {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=item}}
+      </div>
+    </li>
+    {{/each}}
+  </ol>
+  {{!-- Containers items --}}
+  <div id="container" class="item-category-title flexrow">
+    <div class="category-caret"><i class="fas fa-caret-down"></i></div>
+    <div class="category-name">{{localize "OSE.items.Containers"}}</div>
+    <div class="field-short"><i class="fas fa-suitcase"></i></div>
+    <div class="field-short"><i class="fas fa-weight-hanging"></i></div>
+    <div class="item-controls">
+      <a class="item-control item-create" data-type="container" title="{{localize 'OSE.Add'}}"><i
+          class="fa fa-plus"></i></a>
+    </div>
+  </div>
+  <ol class="item-list">
+    {{#each owned.containers as |bag|}}
+    <li class="container item-entry item" data-item-id="{{bag.id}}">
+      <div class="item-header flexrow">
+        <div class="item-image" style="background-image: url({{bag.img}})"></div>
+        <h4 class="item-name" title="{{bag.name}}">
+          {{bag.name~}}
+        </h4>
+        <div class="field-short container-total-weight">
+          {{#if (eq @root.config.encumbrance "basic")}}_{{else if (eq @root.config.encumbrance
+          "detailed")}}_{{else}}{{bag.data.data.totalWeight}}{{/if}}
+        </div>
+        <div class="field-short container-item-weight">
+          {{#if (eq @root.config.encumbrance "basic")}}_{{else if (eq @root.config.encumbrance
+          "detailed")}}_{{else}}{{bag.data.data.weight}}{{/if}}
+        </div>
+        <div class="item-controls">
+          {{#if @root.owner}}
+          <a class="item-control item-edit" title='{{localize "OSE.Edit"}}'><i class="fas fa-edit"></i></a>
+          <a class="item-control item-delete" title='{{localize "OSE.Delete"}}'><i class="fas fa-trash"></i></a>
+          {{/if}}
+        </div>
+      </div>
+      <div class="item-summary">
+        {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=bag}}
+      </div>
+      <div class="item-category-title flexrow">
+        <div class="category-caret"><i class="fas fa-caret-down"></i></div>
+        <div class="category-name">{{bag.name~}}</div>
+        <div class="field-short"><i class="fas fa-suitcase"></i></div>
+        <div class="field-short"><i class="fas fa-weight-hanging"></i></div>
+        <div class="item-controls">
+          <a class="item-control item-create" data-type="container" title="{{localize 'OSE.Add'}}"><i
+              class="fa fa-plus"></i></a>
+        </div>
+      </div>
+      <ol class="item-list">
+        {{#each bag.data.data.itemIds as |item|}}
+        <li class="item-entry item" data-item-id="{{item.id}}">
+          <div class="item-header flexrow">
             <div class="item-image" style="background-image: url({{item.img}})"></div>
-            <a>
-              <h4 title="{{item.name}}">
-                {{item.name~}}
-              </h4>
-            </a>
-          </div>
-          <div class="field-short">
-            {{#if @root.config.ascendingAC}}
-            {{item.data.data.aac.value}}
-            {{else}}
-            {{item.data.data.ac.value}}
-            {{/if}}
-          </div>
-          <div class="field-short">
-            {{#if (eq @root.config.encumbrance "basic")}}_{{else}}{{item.data.data.weight}}{{/if}}
-          </div>
-          <div class="item-controls">
-            {{#if @root.owner}}
-            <a class="item-control item-toggle {{#unless item.data.data.equipped}}item-unequipped{{/unless}}"
-              title='{{localize "OSE.items.Equip"}}'>
-              <i class="fas fa-tshirt"></i>
-            </a>
-            <a class="item-control item-edit" title='{{localize "OSE.Edit"}}'><i class="fas fa-edit"></i></a>
-            <a class="item-control item-delete" title='{{localize "OSE.Delete"}}'><i class="fas fa-trash"></i></a>
-            {{/if}}
-          </div>
-        </div>
-        <div class="item-summary">
-          {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=item}}
-        </div>
-      </li>
-      {{/each}}
-    </ol>
-  </div>
-  <div class="">
-    {{!-- Containers items --}}
-    <li class="item-titles flexrow">
-      <div class="item-caret"><i class="fas fa-caret-down"></i></div>
-      <div class="item-name">{{localize "OSE.items.Containers"}}</div>
-      <div class="field-short"><i class="fas fa-suitcase"></i></div>
-      <div class="field-short"><i class="fas fa-weight-hanging"></i></div>
-      <div class="item-controls">
-        <a class="item-control item-create" data-type="container" title="{{localize 'OSE.Add'}}"><i
-            class="fa fa-plus"></i></a>
-      </div>
-    </li>
-    <ol class="item-list">
-      {{#each owned.containers as |bag|}}
-      <li class="item-entry container">
-        <div class="item item-header flexrow" data-item-id="{{bag.id}}">
-          <div class="item-name flexrow">
-            <div class="item-image" style="background-image: url({{bag.img}})"></div>
-            <a>
-              <h4 title="{{bag.name}}">
-                {{bag.name~}}
-              </h4>
-            </a>
-          </div>
-          <div class="field-short">
-            {{#if (eq @root.config.encumbrance "basic")}}_{{else if (eq @root.config.encumbrance
-            "detailed")}}_{{else}}{{bag.data.data.totalWeight}}{{/if}}
-          </div>
-          <div class="field-short">
-            {{#if (eq @root.config.encumbrance "basic")}}_{{else if (eq @root.config.encumbrance
-            "detailed")}}_{{else}}{{bag.data.data.weight}}{{/if}}
-          </div>
-          <div class="item-controls">
-            {{#if @root.owner}}
-            <a class="item-control item-edit" title='{{localize "OSE.Edit"}}'><i class="fas fa-edit"></i></a>
-            <a class="item-control item-delete" title='{{localize "OSE.Delete"}}'><i class="fas fa-trash"></i></a>
-            {{/if}}
-          </div>
-        </div>
-        <div class="item-summary">
-          {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=item}}
-        </div>
-        <div class="item-gallery">
-          {{#each bag.data.data.itemIds as |item|}}
-          <div class="item-entry">
-            <div class="item item-square" data-item-id="{{item.id}}">
-              <div class="item-control item-edit item-image" style="background-image: url({{item.img}})" title="{{item.name}}"></div>
-              {{#if item.data.data.quantity.value}}
-              <span class="item-quantity">{{item.data.data.quantity.value}}</span>
+            <h4 class="item-name" title="{{item.name}}">
+              {{item.name~}}
+            </h4>
+            <div class="field-short quantity">
+              <input value="{{item.data.data.quantity.value}}" type="text" placeholder="0" />{{#if
+              item.data.data.quantity.max}}<span>/{{item.data.data.quantity.max}}</span>{{/if}}
+            </div>
+            <div class="field-short">
+              {{#if (eq @root.config.encumbrance "basic")}}_{{else if (eq @root.config.encumbrance
+              "detailed")}}_{{else}}{{item.data.data.weight}}{{/if}}
+            </div>
+            <div class="item-controls">
+              {{#if @root.owner}}
+              <a class="item-control item-edit" title='{{localize "OSE.Edit"}}'><i class="fas fa-edit"></i></a>
+              <a class="item-control item-delete" title='{{localize "OSE.Delete"}}'><i class="fas fa-trash"></i></a>
               {{/if}}
             </div>
           </div>
-          {{/each}}
-        </div>
-      </li>
-      {{/each}}
-    </ol>
+          {{#if item.data.data.quantity.max }}
+          {{#if (lte item.data.data.quantity.max 38)}}
+          <div class="consumable-counter">
+            <label>{{localize "OSE.items.uses"}}</label>
+            {{#times item.data.data.quantity.value}}<div class="full-mark"></div>{{/times}}
+            {{#times (subtract item.data.data.quantity.max item.data.data.quantity.value)}}<div class="empty-mark">
+            </div>
+            {{/times}}
+          </div>
+          {{/if}}
+          {{/if}}
+          <div class="item-summary">
+            {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=item}}
+          </div>
+        </li>
+        {{/each}}
+      </ol>
+    </li>
+    {{/each}}
+  </ol>
+  {{!-- Misc items --}}
+  <div id="gear" class="item-category-title flexrow">
+    <div class="category-caret"><i class="fas fa-caret-down"></i></div>
+    <div class="category-name">{{localize "OSE.items.Misc"}}</div>
+    <div class="field-short"><i class="fas fa-hashtag"></i></div>
+    <div class="field-short"><i class="fas fa-weight-hanging"></i></div>
+    <div class="item-controls">
+      <a class="item-control item-create" data-type="item" title="{{localize 'OSE.Add'}}"><i class="fa fa-plus"></i></a>
+    </div>
   </div>
-  <div class="">
-    {{!-- Misc items --}}
-    <li class="item-titles flexrow">
-      <div class="item-caret"><i class="fas fa-caret-down"></i></div>
-      <div class="item-name">{{localize "OSE.items.Misc"}}</div>
-      <div class="field-short"><i class="fas fa-hashtag"></i></div>
-      <div class="field-short"><i class="fas fa-weight-hanging"></i></div>
-      <div class="item-controls">
-        <a class="item-control item-create" data-type="item" title="{{localize 'OSE.Add'}}"><i
-            class="fa fa-plus"></i></a>
+  <ol class="item-list">
+    {{#each owned.items as |item|}}
+    <li class="item-entry item" data-item-id="{{item.id}}">
+      <div class="item-header flexrow">
+        <div class="item-image" style="background-image: url({{item.img}})"></div>
+        <h4 class="item-name" title="{{item.name}}">
+          {{item.name~}}
+        </h4>
+        <div class="field-short quantity">
+          <input value="{{item.data.data.quantity.value}}" type="text" placeholder="0" />{{#if
+          item.data.data.quantity.max}}<span>/{{item.data.data.quantity.max}}</span>{{/if}}
+        </div>
+        <div class="field-short">
+          {{#if (eq @root.config.encumbrance "basic")}}_{{else if (eq @root.config.encumbrance
+          "detailed")}}_{{else}}{{item.data.data.weight}}{{/if}}
+        </div>
+        <div class="item-controls">
+          {{#if @root.owner}}
+          <a class="item-control item-edit" title='{{localize "OSE.Edit"}}'><i class="fas fa-edit"></i></a>
+          <a class="item-control item-delete" title='{{localize "OSE.Delete"}}'><i class="fas fa-trash"></i></a>
+          {{/if}}
+        </div>
+      </div>
+      {{#if item.data.data.quantity.max }}
+      {{#if (lte item.data.data.quantity.max 38)}}
+      <div class="consumable-counter">
+        <label>{{localize "OSE.items.uses"}}</label>
+        {{#times item.data.data.quantity.value}}<div class="full-mark"></div>{{/times}}
+        {{#times (subtract item.data.data.quantity.max item.data.data.quantity.value)}}<div class="empty-mark"></div>
+        {{/times}}
+      </div>
+      {{/if}}
+      {{/if}}
+      <div class="item-summary">
+        {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=item}}
       </div>
     </li>
-    <ol class="item-list">
-      {{#each owned.items as |item|}}
-      <li class="item-entry">
-        <div class="item item-header flexrow" data-item-id="{{item.id}}">
-          <div class="item-name flexrow">
-            <div class="item-image" style="background-image: url({{item.img}})"></div>
-            <a>
-              <h4 title="{{item.name}}">
-                {{item.name~}}
-              </h4>
-            </a>
-          </div>
-          <div class="field-short quantity">
-            <input value="{{item.data.data.quantity.value}}" type="text" placeholder="0" />{{#if
-            item.data.data.quantity.max}}<span>/{{item.data.data.quantity.max}}</span>{{/if}}
-          </div>
-          <div class="field-short">
-            {{#if (eq @root.config.encumbrance "basic")}}_{{else if (eq @root.config.encumbrance
-            "detailed")}}_{{else}}{{item.data.data.weight}}{{/if}}
-          </div>
-          <div class="item-controls">
-            {{#if @root.owner}}
-            <a class="item-control item-edit" title='{{localize "OSE.Edit"}}'><i class="fas fa-edit"></i></a>
-            <a class="item-control item-delete" title='{{localize "OSE.Delete"}}'><i class="fas fa-trash"></i></a>
-            {{/if}}
-          </div>
-        </div>
-        {{#if item.data.data.quantity.max}}
-        {{#if (lte item.data.data.quantity.max 38)}}
-        <div class="consumable-counter">
-          <label>{{localize "OSE.items.uses"}}</label>
-          {{#times item.data.data.quantity.value}}<div class="full-mark"></div>{{/times}}
-          {{#times (subtract item.data.data.quantity.max item.data.data.quantity.value)}}<div class="empty-mark"></div>
-          {{/times}}
-        </div>
-        {{/if}}
-        {{/if}}
-        <div class="item-summary">
-          {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=item}}
-        </div>
-      </li>
-      {{/each}}
-    </ol>
+    {{/each}}
+  </ol>
+  {{!-- Treasure items --}}
+  <div id="treasure" class="item-category-title flexrow">
+    <div class="category-caret"><i class="fas fa-caret-down"></i></div>
+    <div class="category-name">{{localize "OSE.items.Treasure"}}</div>
+    <div class="field-long">{{data.treasure}} <i class="fas fa-circle"></i></div>
+    <div class="field-short"><i class="fas fa-hashtag"></i></div>
+    <div class="field-short"><i class="fas fa-weight-hanging"></i></div>
+    <div class="item-controls">
+      <a class="item-control item-create" data-type="item" data-treasure="true" title="{{localize 'OSE.Add'}}"><i
+          class="fa fa-plus"></i></a>
+    </div>
   </div>
-  <div class="">
-    {{!-- Treasure items --}}
-    <li class="item-titles flexrow">
-      <div class="item-caret"><i class="fas fa-caret-down"></i></div>
-      <div class="item-name">{{localize "OSE.items.Treasure"}}</div>
-      <div class="field-long">{{data.treasure}} <i class="fas fa-circle"></i></div>
-      <div class="field-short"><i class="fas fa-hashtag"></i></div>
-      <div class="field-short"><i class="fas fa-weight-hanging"></i></div>
-      <div class="item-controls">
-        <a class="item-control item-create" data-type="item" data-treasure="true" title="{{localize 'OSE.Add'}}"><i
-            class="fa fa-plus"></i></a>
+  <ol class="item-list">
+    {{#each owned.treasures as |item|}}
+    <li class="item-entry item" data-item-id="{{item.id}}">
+      <div class="item-header flexrow">
+        <div class="item-image" style="background-image: url({{item.img}})"></div>
+        <h4 class="item-name" title="{{item.name}}">
+          {{item.name~}}
+        </h4>
+        <div class="field-long">{{mult item.data.data.quantity.value item.data.data.cost}}</div>
+        <div class="field-short quantity">
+          <input value="{{item.data.data.quantity.value}}" type="text" placeholder="0" />
+          {{#if item.data.data.quantity.max}}
+          <span>/{{item.data.data.quantity.max}}</span>
+          {{/if}}
+        </div>
+        <div class="field-short">
+          {{mult item.data.data.quantity.value item.data.data.weight}}
+        </div>
+        <div class="item-controls">
+          {{#if @root.owner}}
+          <a class="item-control item-edit" title='{{localize "OSE.Edit"}}'><i class="fas fa-edit"></i></a>
+          <a class="item-control item-delete" title='{{localize "OSE.Delete"}}'><i class="fas fa-trash"></i></a>
+          {{/if}}
+        </div>
+      </div>
+      <div class="item-summary">
+        {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=item}}
       </div>
     </li>
-    <ol class="item-list">
-      {{#each owned.treasures as |item|}}
-      <li class="item-entry">
-        <div class="item item-header flexrow" data-item-id="{{item.id}}">
-          <div class="item-name flexrow">
-            <div class="item-image" style="background-image: url({{item.img}})"></div>
-            <a>
-              <h4 title="{{item.name}}">
-                {{item.name~}}
-              </h4>
-            </a>
-          </div>
-          <div class="field-long">{{mult item.data.data.quantity.value item.data.data.cost}}</div>
-          <div class="field-short quantity">
-            <input value="{{item.data.data.quantity.value}}" type="text" placeholder="0" />{{#if
-            item.data.data.quantity.max}}<span>/{{item.data.data.quantity.max}}</span>{{/if}}
-          </div>
-          <div class="field-short">
-            {{mult item.data.data.quantity.value item.data.data.weight}}
-          </div>
-          <div class="item-controls">
-            {{#if @root.owner}}
-            <a class="item-control item-edit" title='{{localize "OSE.Edit"}}'><i class="fas fa-edit"></i></a>
-            <a class="item-control item-delete" title='{{localize "OSE.Delete"}}'><i class="fas fa-trash"></i></a>
-            {{/if}}
-          </div>
-        </div>
-        <div class="item-summary">
-          {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=item}}
-        </div>
-      </li>
-      {{/each}}
-    </ol>
-  </div>
+    {{/each}}
+  </ol>
 </section>
 <section>
   {{#with data.encumbrance}}

--- a/src/templates/actors/partials/character-notes-tab.html
+++ b/src/templates/actors/partials/character-notes-tab.html
@@ -2,7 +2,7 @@
     <div class="inventory">
         <div class="flexrow">
             <div class="languages">
-                <div class="item-titles flexrow">
+                <div class="item-category-title flexrow">
                     <div class="item-name">
                         {{localize "OSE.category.languages"}}
                     </div>
@@ -19,23 +19,23 @@
                         </div>
                         <div class="item-controls">
                             <a class="item-control item-pop" data-array="languages" title="{{localize 'OSE.Del'}}"><i
-                                class="fa fa-trash"></i></a>
+                                    class="fa fa-trash"></i></a>
                         </div>
                     </li>
                     {{/each}}
                 </ol>
             </div>
             <div class="flex3 description">
-                <div class="item-titles">{{localize "OSE.category.description"}}</div>
+                <div class="item-category-title">{{localize "OSE.category.description"}}</div>
                 <div>
                     {{editor content=data.details.description target="data.details.description"
-                button=true owner=owner editable=editable}}
+                    button=true owner=owner editable=editable}}
                 </div>
             </div>
         </div>
     </div>
     <div class="inventory notes">
-        <div class="item-titles">{{localize "OSE.category.notes"}}</div>
+        <div class="item-category-title">{{localize "OSE.category.notes"}}</div>
         <div class="resizable-editor" data-editor-size="140">
             {{editor content=data.details.notes target="data.details.notes"
             button=true owner=owner editable=editable}}

--- a/src/templates/actors/partials/character-spells-tab.html
+++ b/src/templates/actors/partials/character-spells-tab.html
@@ -1,59 +1,57 @@
 <section class="inventory spells resizable" data-base-size="320">
-  <div class="item-titles flexrow" style="line-height:15px">
-    <div class="item-name">{{localize "OSE.category.spells"}}</div>
+  <div class="item-category-title flexrow" style="line-height:15px">
+    <div class="category-name">{{localize "OSE.category.spells"}}</div>
     <div class="item-controls">
-      <a class="item-control item-reset" title='{{localize "OSE.spells.ResetSlots"}}' data-action="reset-spells"><i class="fas fa-sync"></i></a>
+      <a class="item-control item-reset" title='{{localize "OSE.spells.ResetSlots"}}' data-action="reset-spells"><i
+          class="fas fa-sync"></i></a>
       <a class="item-control item-create" data-type="spell" title="{{localize 'OSE.Add'}}"><i
           class="fa fa-plus"></i></a>
     </div>
   </div>
   {{#each spells as |spellGroup id|}}
-  <div>
-    <li class="item-titles flexrow">
-      <div class="item-caret"><i class="fas fa-caret-down"></i> </div>
-      <div class="item-name">{{localize "OSE.spells.Level"}} {{id}}</div>
-      <div class="field-short">{{localize 'OSE.spells.Slots'}}</div>
-      <div class="field-long flexrow">
-        <input type="text" value="{{lookup @root.slots.used @key}}" name="data.spells.{{id}}.value" data-dtype="Number"
-          placeholder="0" disabled title="{{localize 'OSE.spells.MemorizedSlotsHint'}}">/<input type="text" value="{{lookup (lookup @root.data.spells @key) 'max'}}"
-          name="data.spells.{{id}}.max" data-dtype="Number" placeholder="0" title="{{localize 'OSE.spells.MaximumSlotsHint'}}"></div>
-      <div class="item-controls">
-        <a class="item-control item-create" data-type="spell" data-lvl="{{id}}" title="{{localize 'OSE.Add'}}"><i
-            class="fa fa-plus"></i></a>
+  <div class="item-category-title flexrow">
+    <div class="category-caret"><i class="fas fa-caret-down"></i> </div>
+    <div class="category-name">{{localize "OSE.spells.Level"}} {{id}}</div>
+    <div class="field-short">{{localize 'OSE.spells.Slots'}}</div>
+    <div class="field-long flexrow">
+      <input type="text" value="{{lookup @root.slots.used @key}}" name="data.spells.{{id}}.value" data-dtype="Number"
+        placeholder="0" disabled title="{{localize 'OSE.spells.MemorizedSlotsHint'}}">/<input type="text"
+        value="{{lookup (lookup @root.data.spells @key) 'max'}}" name="data.spells.{{id}}.max" data-dtype="Number"
+        placeholder="0" title="{{localize 'OSE.spells.MaximumSlotsHint'}}">
+    </div>
+    <div class="item-controls">
+      <a class="item-control item-create" data-type="spell" data-lvl="{{id}}" title="{{localize 'OSE.Add'}}"><i
+          class="fa fa-plus"></i></a>
+    </div>
+  </div>
+  <ol class="item-list">
+    {{#each spellGroup as |item|}}
+    <li class="item-entry item" data-item-id="{{item.id}}">
+      <div class="item-header flexrow item-rollable">
+        <div class="item-image" style="background-image: url({{item.img}})"></div>
+        <h4 class="item-name" title="{{item.name}}">
+          {{item.name~}}
+        </h4>
+        <div class="field-long memorize flexrow">
+          <input type="text" value="{{item.data.data.cast}}" data-dtype="Number" placeholder="0" data-field="cast"
+            title="{{localize 'OSE.spells.Cast'}}">
+          /
+          <input type="text" value="{{item.data.data.memorized}}" data-field="memorize" data-dtype="Number"
+            placeholder="0" title="{{localize 'OSE.spells.Memorized'}}">
+        </div>
+        <div class="item-controls">
+          {{#if ../../owner}}
+          <a class="item-control item-show" title='{{localize "OSE.Show"}}'><i class="fas fa-eye"></i></a>
+          <a class="item-control item-edit" title='{{localize "OSE.Edit"}}'><i class="fas fa-edit"></i></a>
+          <a class="item-control item-delete" title='{{localize "OSE.Delete"}}'><i class="fas fa-trash"></i></a>
+          {{/if}}
+        </div>
+      </div>
+      <div class="item-summary">
+        {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=item}}
       </div>
     </li>
-    <ol class="item-list">
-      {{#each spellGroup as |item|}}
-      <li class="item-entry">
-        <div class="item item-header flexrow" data-item-id="{{item.id}}">
-          <div class="item-name item-rollable flexrow">
-            <div class="item-image" style="background-image: url({{item.img}})"></div>
-            <a>
-              <h4 title="{{item.name}}">
-                {{item.name~}}
-              </h4>
-            </a>
-          </div>
-          <div class="field-long memorize flexrow">
-            <input type="text" value="{{item.data.data.cast}}" data-dtype="Number" placeholder="0" data-field="cast"
-              title="{{localize 'OSE.spells.Cast'}}">
-            /
-            <input type="text" value="{{item.data.data.memorized}}" data-field="memorize" data-dtype="Number" placeholder="0"
-              title="{{localize 'OSE.spells.Memorized'}}"></div>
-          <div class="item-controls">
-            {{#if ../../owner}}
-            <a class="item-control item-show" title='{{localize "OSE.Show"}}'><i class="fas fa-eye"></i></a>
-            <a class="item-control item-edit" title='{{localize "OSE.Edit"}}'><i class="fas fa-edit"></i></a>
-            <a class="item-control item-delete" title='{{localize "OSE.Delete"}}'><i class="fas fa-trash"></i></a>
-            {{/if}}
-          </div>
-        </div>
-        <div class="item-summary">
-          {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=item}}
-        </div>
-      </li>
-      {{/each}}
-    </ol>
-  </div>
+    {{/each}}
+  </ol>
   {{/each}}
 </section>

--- a/src/templates/actors/partials/character-spells-tab.html
+++ b/src/templates/actors/partials/character-spells-tab.html
@@ -25,7 +25,7 @@
     <ol class="item-list">
       {{#each spellGroup as |item|}}
       <li class="item-entry">
-        <div class="item flexrow" data-item-id="{{item.id}}">
+        <div class="item item-header flexrow" data-item-id="{{item.id}}">
           <div class="item-name item-rollable flexrow">
             <div class="item-image" style="background-image: url({{item.img}})"></div>
             <a>
@@ -47,6 +47,9 @@
             <a class="item-control item-delete" title='{{localize "OSE.Delete"}}'><i class="fas fa-trash"></i></a>
             {{/if}}
           </div>
+        </div>
+        <div class="item-summary">
+          {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=item}}
         </div>
       </li>
       {{/each}}

--- a/src/templates/actors/partials/monster-attributes-tab.html
+++ b/src/templates/actors/partials/monster-attributes-tab.html
@@ -98,7 +98,7 @@
                     <div class="attack-pattern">
                         {{#each section as |item|}}
                         <li class="item-entry">
-                            <div class="item flexrow" data-item-id="{{item.id}}">
+                            <div class="item item-header flexrow" data-item-id="{{item.id}}">
                                 <div class="item-pattern" style="background:{{pattern}};"
                                     title="{{localize 'OSE.items.pattern'}}"><i class="fas fa-link"></i></div>
                                 {{#if (or item.data.data.roll (eq item.type "weapon"))}}
@@ -135,6 +135,9 @@
                                         {{/if}}
                                     </div>
                                 </div>
+                           <div class="item-summary">
+                                {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=item}}
+                            </div>
                         </li>
                         {{/each}}
                     </div>
@@ -144,7 +147,7 @@
                     {{#unless (and (eq id "items") @root.data.config.enableInventory)}}
                     {{#each section as |item|}}
                     <li class="item-entry">
-                        <div class="item flexrow" data-item-id="{{item.id}}">
+                        <div class="item item-header flexrow" data-item-id="{{item.id}}">
                             <div class="item-name flexrow">
                                 <div class="item-image" style="background-image: url({{item.img}})"></div>
                                 <h4 title="{{item.name}}">
@@ -159,6 +162,9 @@
                                         class="fas fa-trash"></i></a>
                                 {{/if}}
                             </div>
+                        </div>
+                        <div class="item-summary">
+                            {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=item}}
                         </div>
                     </li>
                     {{/each}}

--- a/src/templates/actors/partials/monster-attributes-tab.html
+++ b/src/templates/actors/partials/monster-attributes-tab.html
@@ -79,83 +79,50 @@
     <section class="flexrow attribute-row">
         {{!-- Skills and abilities --}}
         <div class="flex3 panel inventory abilities">
-            <div>
-                <li class="item-titles flexrow panel-title">
-                    <div class="item-name">{{localize 'OSE.category.abilities'}} & {{localize 'OSE.category.equipment'}}
-                    </div>
-                    <div class="item-controls">
-                        {{#if owner}}
-                        <a class="item-control item-reset" title='{{localize "OSE.items.resetAttacks"}}' data-action="reset-attacks"><i
-                                class="fas fa-sync"></i></a>
-                        <a class="item-control item-create" title='{{localize "OSE.Add"}}' data-type="choice"
-                            data-choices="weapon,ability,armor,item"><i class="fas fa-plus"></i></a>
-                        {{/if}}
-                    </div>
-                </li>
-                <ol class="item-list resizable" data-base-size="240">
-                    {{! Attack pattern group}}
-                    {{#each attackPatterns as |section pattern|}}
-                    <div class="attack-pattern">
-                        {{#each section as |item|}}
-                        <li class="item-entry">
-                            <div class="item item-header flexrow" data-item-id="{{item.id}}">
-                                <div class="item-pattern" style="background:{{pattern}};"
-                                    title="{{localize 'OSE.items.pattern'}}"><i class="fas fa-link"></i></div>
-                                {{#if (or item.data.data.roll (eq item.type "weapon"))}}
-                                <div class="item-name item-rollable flexrow">
-                                    {{else}}
-                                    <div class="item-name flexrow">
-                                        {{/if}}
-                                        <div class="item-image" style="background-image: url({{item.img}})"></div>
-                                        <h4 title="{{item.name}}">
-                                            {{item.name~}}
-                                        </h4>
-                                    </div>
-                                    {{#if (eq type "weapon")}}
-                                    <div class="field-long counter flexrow">
-                                        <input type="text" value="{{item.data.data.counter.value}}" data-dtype="Number"
-                                            placeholder="0" data-field="value"
-                                            title="{{localize 'OSE.items.roundAttacks'}}">
-                                        /
-                                        <input type="text" value="{{item.data.data.counter.max}}" data-field="max"
-                                            data-dtype="Number" placeholder="0"
-                                            title="{{localize 'OSE.items.roundAttacksMax'}}">
-                                    </div>
-                                    {{/if}}
-                                    <div class="item-controls">
-                                        {{#if @root.owner}}
-                                        {{#if (eq type "ability")}}
-                                        <a class="item-control item-show" title='{{localize "OSE.Show"}}'><i
-                                                class="fas fa-eye"></i></a>
-                                        {{/if}}
-                                        <a class="item-control item-edit" title='{{localize "OSE.Edit"}}'><i
-                                                class="fas fa-edit"></i></a>
-                                        <a class="item-control item-delete" title='{{localize "OSE.Delete"}}'><i
-                                                class="fas fa-trash"></i></a>
-                                        {{/if}}
-                                    </div>
-                                </div>
-                           <div class="item-summary">
-                                {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=item}}
-                            </div>
-                        </li>
-                        {{/each}}
-                    </div>
-                    {{/each}}
-                    {{! Other items}}
-                    {{#each owned as |section id| }}
-                    {{#unless (and (eq id "items") @root.data.config.enableInventory)}}
+            <li class="flexrow panel-title">
+                <div class="category-name">{{localize 'OSE.category.abilities'}} & {{localize
+                    'OSE.category.equipment'}}
+                </div>
+                <div class="item-controls">
+                    {{#if owner}}
+                    <a class="item-control item-reset" title='{{localize "OSE.items.resetAttacks"}}'
+                        data-action="reset-attacks"><i class="fas fa-sync"></i></a>
+                    <a class="item-control item-create" title='{{localize "OSE.Add"}}' data-type="choice"
+                        data-choices="weapon,ability,armor,item"><i class="fas fa-plus"></i></a>
+                    {{/if}}
+                </div>
+            </li>
+            <ol class="item-list resizable" data-base-size="240">
+                {{! Attack pattern group}}
+                {{#each attackPatterns as |section pattern|}}
+                <ol class="attack-pattern">
                     {{#each section as |item|}}
-                    <li class="item-entry">
-                        <div class="item item-header flexrow" data-item-id="{{item.id}}">
-                            <div class="item-name flexrow">
-                                <div class="item-image" style="background-image: url({{item.img}})"></div>
-                                <h4 title="{{item.name}}">
-                                    {{item.name~}}
-                                </h4>
+                    <li class="item-entry {{#if (or item.data.data.roll (eq item.type 'weapon'))}}item-rollable{{/if}}"
+                        data-item-id="{{item.id}}">
+                        <div class="item-header flexrow">
+                            <div class="item-pattern pattern-{{pattern}}" title="{{localize 'OSE.items.pattern'}}">
+                                <i class="fas fa-link"></i>
                             </div>
+                            <div class="item-image" style="background-image: url({{item.img}})"></div>
+                            <h4 class="item-name" title="{{item.name}}">
+                                {{item.name~}}
+                            </h4>
+                            {{#if (eq type "weapon")}}
+                            <div class="field-long counter flexrow">
+                                <input type="text" value="{{item.data.data.counter.value}}" data-dtype="Number"
+                                    placeholder="0" data-field="value" title="{{localize 'OSE.items.roundAttacks'}}">
+                                /
+                                <input type="text" value="{{item.data.data.counter.max}}" data-field="max"
+                                    data-dtype="Number" placeholder="0"
+                                    title="{{localize 'OSE.items.roundAttacksMax'}}">
+                            </div>
+                            {{/if}}
                             <div class="item-controls">
                                 {{#if @root.owner}}
+                                {{#if (eq type "ability")}}
+                                <a class="item-control item-show" title='{{localize "OSE.Show"}}'><i
+                                        class="fas fa-eye"></i></a>
+                                {{/if}}
                                 <a class="item-control item-edit" title='{{localize "OSE.Edit"}}'><i
                                         class="fas fa-edit"></i></a>
                                 <a class="item-control item-delete" title='{{localize "OSE.Delete"}}'><i
@@ -168,10 +135,36 @@
                         </div>
                     </li>
                     {{/each}}
-                    {{/unless}}
-                    {{/each}}
                 </ol>
-            </div>
+                {{/each}}
+                {{! Other items}}
+                {{#each owned as |section id| }}
+                {{#unless (and (eq id "items") @root.data.config.enableInventory)}}
+                {{#each section as |item|}}
+                <li class="item-entry" data-item-id="{{item.id}}">
+                    <div class="item-header flexrow">
+                        <div class="item-image" style="background-image: url({{item.img}})"></div>
+                        <h4 class="item-name" title="{{item.name}}">
+                            {{item.name~}}
+                        </h4>
+                        {{#if @root.owner}}
+                        <div class="item-controls">
+                            <a class="item-control item-edit" title='{{localize "OSE.Edit"}}'><i
+                                    class="fas fa-edit"></i></a>
+                            <a class="item-control item-delete" title='{{localize "OSE.Delete"}}'><i
+                                    class="fas fa-trash"></i></a>
+
+                        </div>
+                        {{/if}}
+                    </div>
+                    <div class="item-summary">
+                        {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=item}}
+                    </div>
+                </li>
+                {{/each}}
+                {{/unless}}
+                {{/each}}
+            </ol>
         </div>
         {{!-- Saving throws --}}
         <div class="attribute-group">

--- a/src/templates/items/weapon-sheet.html
+++ b/src/templates/items/weapon-sheet.html
@@ -1,50 +1,30 @@
 <form class="{{cssClass}}" autocomplete="off">
   <header class="sheet-header">
-    <img
-      class="profile-img"
-      src="{{img}}"
-      data-edit="img"
-      title="{{name}}"
-      />
+    <img class="profile-img" src="{{img}}" data-edit="img" title="{{name}}" />
     <div class="header-col">
       <div class="flexrow">
         <h1 class="charname">
-          <input
-            name="name"
-            type="text"
-            value="{{name}}"
-            placeholder="Name"
-            />
+          <input name="name" type="text" value="{{name}}" placeholder="Name" />
         </h1>
         <div class="details">
           <div class="form-group">
             <label title="{{localize 'OSE.items.Cost'}}"><i class="fas
                 fa-circle"></i></label>
             <div class="form-fields">
-              <input
-                type="text"
-                name="data.cost"
-                value="{{data.cost}}"
-                data-dtype="Number"
-                />
+              <input type="text" name="data.cost" value="{{data.cost}}" data-dtype="Number" />
             </div>
           </div>
           <div class="form-group">
             <label title="{{localize 'OSE.items.Weight'}}"><i class="fas
                 fa-weight-hanging"></i></label>
             <div class="form-fields">
-              <input
-                type="text"
-                name="data.weight"
-                value="{{data.weight}}"
-                data-dtype="Number"
-                />
+              <input type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number" />
             </div>
           </div>
         </div>
       </div>
       <ol class="tag-list">
-        {{#each data.tags as |tag|}}
+        {{#each data.manualTags as |tag|}}
         <li class="tag" title="{{tag.title}}" data-tag="{{tag.value}}">
           <span>{{tag.value}}</span>
           <a class="tag-delete"><i class="fas fa-times"></i></a>
@@ -58,35 +38,21 @@
       <div class="stats">
         <div class="form-group">
           <div class="form-fields">
-            <input
-              type="text"
-              data-action="add-tag"
-              title="{{localize 'OSE.items.typeTag'}}"
-              placeholder="{{localize 'OSE.items.enterTag'}}"
-              />
+            <input type="text" data-action="add-tag" title="{{localize 'OSE.items.typeTag'}}"
+              placeholder="{{localize 'OSE.items.enterTag'}}" />
           </div>
         </div>
         <div class="form-group block-input">
           <label>{{localize 'OSE.items.Damage'}}</label>
           <div class="form-fields">
-            <input
-              type="text"
-              name="data.damage"
-              value="{{data.damage}}"
-              data-dtype="String"
-              />
+            <input type="text" name="data.damage" value="{{data.damage}}" data-dtype="String" />
           </div>
         </div>
         <div class="form-group">
           <label title="{{localize 'OSE.items.AtkBonus'}}">{{localize
             'OSE.items.Bonus'}}</label>
           <div class="form-fields">
-            <input
-              type="text"
-              name="data.bonus"
-              value="{{data.bonus}}"
-              data-dtype="Number"
-              />
+            <input type="text" name="data.bonus" value="{{data.bonus}}" data-dtype="Number" />
           </div>
         </div>
         <div class="form-group attack-type">
@@ -99,26 +65,11 @@
         <div class="form-group block-input">
           <label>{{localize 'OSE.items.Range'}}</label>
           <div class="form-fields range">
-            <input
-              type="text"
-              name="data.range.short"
-              value="{{data.range.short}}"
-              data-dtype="Number"
-              />
-              <div class="sep"></div>
-              <input
-              type="text"
-              name="data.range.medium"
-              value="{{data.range.medium}}"
-              data-dtype="Number"
-              />
-              <div class="sep"></div>
-              <input
-              type="text"
-              name="data.range.long"
-              value="{{data.range.long}}"
-              data-dtype="Number"
-              />
+            <input type="text" name="data.range.short" value="{{data.range.short}}" data-dtype="Number" />
+            <div class="sep"></div>
+            <input type="text" name="data.range.medium" value="{{data.range.medium}}" data-dtype="Number" />
+            <div class="sep"></div>
+            <input type="text" name="data.range.long" value="{{data.range.long}}" data-dtype="Number" />
           </div>
         </div>
         {{/if}}
@@ -138,14 +89,7 @@
         <div class="form-group">
           <label>{{localize 'OSE.items.Slow'}}</label>
           <div class="form-fields">
-            <input
-              type="checkbox"
-              name="data.slow"
-              value="{{data.slow}}"
-              {{checked
-              data.slow}}
-              data-dtype="Number"
-              />
+            <input type="checkbox" name="data.slow" value="{{data.slow}}" {{checked data.slow}} data-dtype="Number" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
**New Features**

* Content of containers is displayed as a category (like Weapons, Armor or Treasure) linked to the container item display, to enable ease of use and readability of their content
* Monsters' attack pattern groups are now separated by a small margin for ease of readability (a happy little accident I found neat while refactoring the internal structure of this display)

**Internal refactor**
Oh god so much stuff (<- this is not mandatory to include in the release notes)

* Item summary display (for weapons, armors, items, containers, treasure, monster abilities, spells, etc.) is no longer generated with JS, but is contained in an Handlebars template
* Item tags are now accessible in two data fields: `data.autoTags` and `data.manualTags`, which respectively represents tags derived from the item qualities (Armor weight, Weapon usage, Class needed for a Spell, Ability roll, etc.) and tags added manually to weapons (the system could be extended to other Items, e.g. to mark armors as magic, or treasure as cursed). Template usage have been adjusted accordingly. 
* Item categories internal structure is simpler (alternating Title -> Items -> Title -> Items -> etc.) instead of the monstrosity of divs inside divs inside divs (for the Inventory tab and the Spells tabs)
  * Same deal for Item element in the inventory lists, with a consistent structure across all kind of Items displayed
  * Which also means that the CSS has been adjusted to match the new structure
* Any event handling methods that was in either character-sheet.js or monster-sheet.js (or most of the time, in both, but with very subtle differences, like naming) has been factorized in actor-sheet.js, from which both JS classes inherits
* Speaking of event handling, methods bound to events and longer than 3 lines have been extracted as private methods (well, in methods prefixed with `_`, if this is how private methods are handled in JS) for code readability
