### PR TITLE
Fix/display tags item directory

### DIFF
--- a/src/module/item/entity.js
+++ b/src/module/item/entity.js
@@ -222,21 +222,6 @@ export class OseItem extends Item {
     return tagList;
   }
 
-  getAutoTagDisplay() {
-    let formatTag = (tag, icon) => {
-      if (!tag) return "";
-      tag = tag.trim();
-      let fa = "";
-      if (icon) {
-        fa = `<i class="fas ${icon}"></i> `;
-      }
-      return `<li class='tag'>${fa}${tag}</li>`;
-    };
-    return this.getAutoTagList().reduce((acc, v) => {
-      return `${acc}${formatTag(v.label, v.icon)}`;
-    }, "");
-  }
-
   pushManualTag(values) {
     const data = this.data.data;
     let update = [];

--- a/src/module/preloadTemplates.js
+++ b/src/module/preloadTemplates.js
@@ -15,6 +15,9 @@ export const preloadHandlebarsTemplates = async function () {
     "systems/ose/dist/templates/actors/partials/monster-header.html",
     "systems/ose/dist/templates/actors/partials/monster-attributes-tab.html",
 
+    // Item Display
+    "systems/ose/dist/templates/actors/partials/item-auto-tags-partial.html",
+
     // Party Sheet
     "systems/ose/dist/templates/apps/party-sheet.html",
     "systems/ose/dist/templates/apps/party-xp.html",

--- a/src/module/renderList.js
+++ b/src/module/renderList.js
@@ -1,17 +1,19 @@
+import { OseItem } from "./item/entity";
+
 export const RenderCompendium = async function (object, html, d) {
   if (object.documentName != "Item") {
     return;
   }
   const render = html[0].querySelectorAll(".item");
   const docs = await d.collection.getDocuments();
-  render.forEach(function (item, i) {
+
+  render.forEach(async function (item, i) {
     const id = render[i].dataset.documentId;
+
     const element = docs.filter((d) => d.id === id)[0];
-    const tagList = document.createElement("ol");
-    tagList.classList.add("tag-list");
-    const tags = element.getAutoTagDisplay();
-    tagList.innerHTML = tags;
-    item.appendChild(tagList);
+    const tagTemplate = $.parseHTML(await renderTemplate("systems/ose/dist/templates/actors/partials/item-auto-tags-partial.html", {tags: OseItem.prototype.getAutoTagList.call(element)}));
+
+    $(item).append(tagTemplate);
   });
 };
 
@@ -19,16 +21,17 @@ export const RenderDirectory = async function (object, html) {
   if (object.id != "items") {
     return;
   }
+  
   const render = html[0].querySelectorAll(".item");
   const content = object.documents;
-  render.forEach(function (item) {
-    const tagList = document.createElement("ol");
-    tagList.classList.add("tag-list");
+
+  render.forEach(async function (item) {
+
     const foundryDocument = content.find(
       (e) => e.id == item.dataset.documentId
     );
-    const tags = foundryDocument.getAutoTagDisplay();
-    tagList.innerHTML = tags;
-    item.appendChild(tagList);
+
+    const tagTemplate = $.parseHTML(await renderTemplate("systems/ose/dist/templates/actors/partials/item-auto-tags-partial.html", {tags: OseItem.prototype.getAutoTagList.call(foundryDocument)}));
+    $(item).append(tagTemplate);
   });
 };

--- a/src/templates/actors/partials/actor-item-summary.html
+++ b/src/templates/actors/partials/actor-item-summary.html
@@ -1,15 +1,4 @@
 <div class="item-description">
-  <ol class="tag-list">
-    {{#each item.data.data.autoTags as |tag|}}
-    {{#if tag.label}}
-    <li class="tag">
-      {{#if tag.icon}}
-      <i class="fas {{tag.icon}}"></i>
-      {{/if}}
-      {{tag.label~}}
-    </li>
-    {{/if}}
-    {{/each}}
-  </ol>
+  {{> "systems/ose/dist/templates/actors/partials/item-auto-tags-partial.html" tags=item.data.data.autoTags}}
   <div>{{{item.data.data.description}}}</div>
 </div>

--- a/src/templates/actors/partials/item-auto-tags-partial.html
+++ b/src/templates/actors/partials/item-auto-tags-partial.html
@@ -1,0 +1,12 @@
+<ol class="tag-list">
+  {{#each tags as |tag|}}
+  {{#if tag.label}}
+  <li class="tag">
+    {{#if tag.icon}}
+    <i class="fas {{tag.icon}}"></i>
+    {{/if}}
+    {{tag.label~}}
+  </li>
+  {{/if}}
+  {{/each}}
+</ol>


### PR DESCRIPTION
I moved the tag list block, displaying information in the item summary, to a template, and used that template to fix the display of tags in the sidebar directories