### PR TITLE
Re-add a HTML class required for abilities drag&drop from inventory

### DIFF
--- a/src/templates/actors/partials/character-abilities-tab.html
+++ b/src/templates/actors/partials/character-abilities-tab.html
@@ -51,7 +51,7 @@
   </div>
   <ol class="item-list resizable" data-base-size="260">
     {{#each abilities as |item|}}
-    <li class="item-entry" data-item-id="{{item.id}}">
+    <li class="item-entry item" data-item-id="{{item.id}}">
       <div class="item-header flexrow {{#if item.data.data.roll}}item-rollable{{/if}}">
         <div class="item-image" style="background-image: url({{item.img}})"></div>
         <h4 class="item-name" title="{{item.name}}">


### PR DESCRIPTION
I removed a class on the HTML of the Item list elements, but the default drag&drop Foundry implementation depends on it, so I added it back