### PR TITLE
Fix: tweaks icon not showing for non gm users

### DIFF
--- a/src/module/actor/actor-sheet.js
+++ b/src/module/actor/actor-sheet.js
@@ -356,7 +356,7 @@ export class OseActorSheet extends ActorSheet {
     let buttons = super._getHeaderButtons();
 
     // Token Configuration
-    const canConfigure = game.user.isGM || this.actor.owner;
+    const canConfigure = game.user.isGM || this.actor.isOwner;
     if (this.options.editable && canConfigure) {
       buttons = [
         {


### PR DESCRIPTION
Fixed incorrect property name that was preventing the tweaks menu from being accessible on a user owned actor sheet.