### PR TITLE
fix: added manualTags and autoTags to system template

### DIFF
--- a/template.json
+++ b/template.json
@@ -159,7 +159,9 @@
     "types": ["item", "weapon", "armor", "spell", "ability", "container"],
     "templates": {
       "common": {
-        "description": ""
+        "description": "",
+        "autoTags": [],
+        "manualTags": []
       },
       "physical": {
         "quantity": {
@@ -183,7 +185,8 @@
       "isContainer": false
     },
     "container": {
-      "templates": ["common", "physical"]
+      "templates": ["common", "physical"],
+      "itemIds": []
     },
     "weapon": {
       "templates": ["common", "physical", "rollable", "equippable"],


### PR DESCRIPTION
My fix to #30 isn't working in 1.4.3 because another upstream change (possibly #134 ?) had not made it to my local machine somehow, or perhaps I was testing with items that were created before that patch had been merged into main.

This is proven to rectify the issue on newly created items. We may need a proper world migration to ensure users don't have issues with items created in the interim of this patch and #134.