### PR TITLE
Fix/template path config

### DIFF
--- a/src/module/actor/actor-sheet.js
+++ b/src/module/actor/actor-sheet.js
@@ -289,7 +289,7 @@ export class OseActorSheet extends ActorSheet {
   async _chooseItemType(choices = ["weapon", "armor", "shield", "gear"]) {
     let templateData = { types: choices },
       dlg = await renderTemplate(
-        `${OSE.systemPath}/templates/items/entity-create.html`,
+        `${OSE.systemPath()}/templates/items/entity-create.html`,
         templateData
       );
     //Create Dialog window

--- a/src/module/actor/actor-sheet.js
+++ b/src/module/actor/actor-sheet.js
@@ -1,5 +1,5 @@
-import { OseActor } from "./entity.js";
-import { OseEntityTweaks } from "../dialog/entity-tweaks.js";
+import { OseEntityTweaks } from "../dialog/entity-tweaks";
+import { OSE } from "../config";
 
 export class OseActorSheet extends ActorSheet {
   constructor(...args) {
@@ -289,7 +289,7 @@ export class OseActorSheet extends ActorSheet {
   async _chooseItemType(choices = ["weapon", "armor", "shield", "gear"]) {
     let templateData = { types: choices },
       dlg = await renderTemplate(
-        "systems/ose/dist/templates/items/entity-create.html",
+        `${OSE.systemPath}/templates/items/entity-create.html`,
         templateData
       );
     //Create Dialog window

--- a/src/module/actor/character-sheet.js
+++ b/src/module/actor/character-sheet.js
@@ -20,7 +20,7 @@ export class OseActorSheetCharacter extends OseActorSheet {
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
       classes: ["ose", "sheet", "actor", "character"],
-      template: `${OSE.systemPath}/templates/actors/character-sheet.html`,
+      template: `${OSE.systemPath()}/templates/actors/character-sheet.html`,
       width: 450,
       height: 530,
       resizable: true,
@@ -135,7 +135,7 @@ export class OseActorSheetCharacter extends OseActorSheet {
 
     let templateData = { choices: choices },
       dlg = await renderTemplate(
-        `${OSE.systemPath}/templates/actors/dialogs/lang-create.html`,
+        `${OSE.systemPath()}/templates/actors/dialogs/lang-create.html`,
         templateData
       );
     //Create Dialog window
@@ -200,7 +200,7 @@ export class OseActorSheetCharacter extends OseActorSheet {
   async _onShowItemTooltip(event) {
     let templateData = {},
       dlg = await renderTemplate(
-        `${OSE.systemPath}/templates/actors/partials/character-item-tooltip.html`,
+        `${OSE.systemPath()}/templates/actors/partials/character-item-tooltip.html`,
         templateData
       );
     document.querySelector(".game").append(dlg);

--- a/src/module/actor/character-sheet.js
+++ b/src/module/actor/character-sheet.js
@@ -1,7 +1,7 @@
-import { OseActor } from "./entity.js";
-import { OseActorSheet } from "./actor-sheet.js";
-import { OseCharacterModifiers } from "../dialog/character-modifiers.js";
-import { OseCharacterCreator } from "../dialog/character-creation.js";
+import { OseActorSheet } from "./actor-sheet";
+import { OseCharacterModifiers } from "../dialog/character-modifiers";
+import { OseCharacterCreator } from "../dialog/character-creation";
+import { OSE } from "../config";
 
 /**
  * Extend the basic ActorSheet with some very simple modifications
@@ -20,7 +20,7 @@ export class OseActorSheetCharacter extends OseActorSheet {
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
       classes: ["ose", "sheet", "actor", "character"],
-      template: "systems/ose/dist/templates/actors/character-sheet.html",
+      template: `${OSE.systemPath}/templates/actors/character-sheet.html`,
       width: 450,
       height: 530,
       resizable: true,
@@ -135,7 +135,7 @@ export class OseActorSheetCharacter extends OseActorSheet {
 
     let templateData = { choices: choices },
       dlg = await renderTemplate(
-        "systems/ose/dist/templates/actors/dialogs/lang-create.html",
+        `${OSE.systemPath}/templates/actors/dialogs/lang-create.html`,
         templateData
       );
     //Create Dialog window
@@ -200,7 +200,7 @@ export class OseActorSheetCharacter extends OseActorSheet {
   async _onShowItemTooltip(event) {
     let templateData = {},
       dlg = await renderTemplate(
-        "systems/ose/dist/templates/actors/partials/character-item-tooltip.html",
+        `${OSE.systemPath}/templates/actors/partials/character-item-tooltip.html`,
         templateData
       );
     document.querySelector(".game").append(dlg);

--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -1,5 +1,5 @@
-import { OseDice } from "../dice.js";
-import { OseItem } from "../item/entity.js";
+import { OseDice } from "../dice";
+import { OseItem } from "../item/entity";
 
 export class OseActor extends Actor {
   /**

--- a/src/module/actor/monster-sheet.js
+++ b/src/module/actor/monster-sheet.js
@@ -1,5 +1,5 @@
-import { OseActor } from "./entity.js";
-import { OseActorSheet } from "./actor-sheet.js";
+import { OseActorSheet } from "./actor-sheet";
+import { OSE } from "../config";
 
 /**
  * Extend the basic ActorSheet with some very simple modifications
@@ -18,7 +18,7 @@ export class OseActorSheetMonster extends OseActorSheet {
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
       classes: ["ose", "sheet", "monster", "actor"],
-      template: "systems/ose/dist/templates/actors/monster-sheet.html",
+      template: `${OSE.systemPath}/templates/actors/monster-sheet.html`,
       width: 450,
       height: 560,
       resizable: true,
@@ -151,7 +151,7 @@ export class OseActorSheetMonster extends OseActorSheet {
 
     let templateData = { choices: choices },
       dlg = await renderTemplate(
-        "systems/ose/dist/templates/actors/dialogs/monster-saves.html",
+        `${OSE.systemPath}/templates/actors/dialogs/monster-saves.html`,
         templateData
       );
     //Create Dialog window

--- a/src/module/actor/monster-sheet.js
+++ b/src/module/actor/monster-sheet.js
@@ -18,7 +18,7 @@ export class OseActorSheetMonster extends OseActorSheet {
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
       classes: ["ose", "sheet", "monster", "actor"],
-      template: `${OSE.systemPath}/templates/actors/monster-sheet.html`,
+      template: `${OSE.systemPath()}/templates/actors/monster-sheet.html`,
       width: 450,
       height: 560,
       resizable: true,
@@ -151,7 +151,7 @@ export class OseActorSheetMonster extends OseActorSheet {
 
     let templateData = { choices: choices },
       dlg = await renderTemplate(
-        `${OSE.systemPath}/templates/actors/dialogs/monster-saves.html`,
+        `${OSE.systemPath()}/templates/actors/dialogs/monster-saves.html`,
         templateData
       );
     //Create Dialog window

--- a/src/module/combat.js
+++ b/src/module/combat.js
@@ -103,7 +103,7 @@ export class OseCombat {
       updates[i].initiative = value;
 
       //render template
-      let template = `${OSE.systemPath}/dist/templates/chat/roll-individual-initiative.html`;
+      let template = `${OSE.systemPath()}/dist/templates/chat/roll-individual-initiative.html`;
       let tData = {
         name: cbt.name,
         formula: roll.formula,

--- a/src/module/combat.js
+++ b/src/module/combat.js
@@ -1,3 +1,5 @@
+import { OSE } from "./config";
+
 export class OseCombat {
   static STATUS_SLOW = -789;
   static STATUS_DIZZY = -790;
@@ -101,8 +103,7 @@ export class OseCombat {
       updates[i].initiative = value;
 
       //render template
-      let template =
-        "systems/ose/dist/templates/chat/roll-individual-initiative.html";
+      let template = `${OSE.systemPath}/dist/templates/chat/roll-individual-initiative.html`;
       let tData = {
         name: cbt.name,
         formula: roll.formula,

--- a/src/module/config.js
+++ b/src/module/config.js
@@ -1,4 +1,5 @@
 export const OSE = {
+  systemPath: "/systems/dev-ose/dist",
   scores: {
     str: "OSE.scores.str.long",
     int: "OSE.scores.int.long",

--- a/src/module/config.js
+++ b/src/module/config.js
@@ -1,5 +1,7 @@
 export const OSE = {
-  systemPath: "/systems/dev-ose/dist",
+  systemPath: () => {
+    return `/systems/${game.system.id}/dist`;
+  },
   scores: {
     str: "OSE.scores.str.long",
     int: "OSE.scores.int.long",

--- a/src/module/dialog/character-creation.js
+++ b/src/module/dialog/character-creation.js
@@ -6,7 +6,7 @@ export class OseCharacterCreator extends FormApplication {
     const options = super.defaultOptions;
     (options.classes = ["ose", "dialog", "creator"]),
       (options.id = "character-creator");
-    options.template = `${OSE.systemPath}/templates/actors/dialogs/character-creation.html`;
+    options.template = `${OSE.systemPath()}/templates/actors/dialogs/character-creation.html`;
     options.width = 235;
     return options;
   }
@@ -127,7 +127,7 @@ export class OseCharacterCreator extends FormApplication {
       gold: this.gold,
     };
     const content = await renderTemplate(
-      `${OSE.systemPath}/templates/chat/roll-creation.html`,
+      `${OSE.systemPath()}/templates/chat/roll-creation.html`,
       templateData
     );
     ChatMessage.create({

--- a/src/module/dialog/character-creation.js
+++ b/src/module/dialog/character-creation.js
@@ -1,13 +1,12 @@
-import { OseActor } from "../actor/entity.js";
-import { OseDice } from "../dice.js";
+import { OseDice } from "../dice";
+import { OSE } from "../config";
 
 export class OseCharacterCreator extends FormApplication {
   static get defaultOptions() {
     const options = super.defaultOptions;
     (options.classes = ["ose", "dialog", "creator"]),
       (options.id = "character-creator");
-    options.template =
-      "systems/ose/dist/templates/actors/dialogs/character-creation.html";
+    options.template = `${OSE.systemPath}/templates/actors/dialogs/character-creation.html`;
     options.width = 235;
     return options;
   }
@@ -128,7 +127,7 @@ export class OseCharacterCreator extends FormApplication {
       gold: this.gold,
     };
     const content = await renderTemplate(
-      "systems/ose/dist/templates/chat/roll-creation.html",
+      `${OSE.systemPath}/templates/chat/roll-creation.html`,
       templateData
     );
     ChatMessage.create({

--- a/src/module/dialog/character-modifiers.js
+++ b/src/module/dialog/character-modifiers.js
@@ -5,7 +5,7 @@ export class OseCharacterModifiers extends FormApplication {
     const options = super.defaultOptions;
     (options.classes = ["ose", "dialog", "modifiers"]),
       (options.id = "sheet-modifiers");
-    options.template = `${OSE.systemPath}/templates/actors/dialogs/modifiers-dialog.html`;
+    options.template = `${OSE.systemPath()}/templates/actors/dialogs/modifiers-dialog.html`;
     options.width = 240;
     return options;
   }

--- a/src/module/dialog/character-modifiers.js
+++ b/src/module/dialog/character-modifiers.js
@@ -1,13 +1,11 @@
-// eslint-disable-next-line no-unused-vars
-import { OseActor } from "../actor/entity.js";
+import { OSE } from "../config";
 
 export class OseCharacterModifiers extends FormApplication {
   static get defaultOptions() {
     const options = super.defaultOptions;
     (options.classes = ["ose", "dialog", "modifiers"]),
       (options.id = "sheet-modifiers");
-    options.template =
-      "systems/ose/dist/templates/actors/dialogs/modifiers-dialog.html";
+    options.template = `${OSE.systemPath}/templates/actors/dialogs/modifiers-dialog.html`;
     options.width = 240;
     return options;
   }

--- a/src/module/dialog/entity-tweaks.js
+++ b/src/module/dialog/entity-tweaks.js
@@ -1,12 +1,10 @@
-// eslint-disable-next-line no-unused-vars
-import { OseActor } from "../actor/entity.js";
+import { OSE } from "../config";
 
 export class OseEntityTweaks extends FormApplication {
   static get defaultOptions() {
     const options = super.defaultOptions;
     options.id = "sheet-tweaks";
-    options.template =
-      "systems/ose/dist/templates/actors/dialogs/tweaks-dialog.html";
+    options.template = `${OSE.systemPath}/templates/actors/dialogs/tweaks-dialog.html`;
     options.width = 380;
     return options;
   }

--- a/src/module/dialog/entity-tweaks.js
+++ b/src/module/dialog/entity-tweaks.js
@@ -4,7 +4,7 @@ export class OseEntityTweaks extends FormApplication {
   static get defaultOptions() {
     const options = super.defaultOptions;
     options.id = "sheet-tweaks";
-    options.template = `${OSE.systemPath}/templates/actors/dialogs/tweaks-dialog.html`;
+    options.template = `${OSE.systemPath()}/templates/actors/dialogs/tweaks-dialog.html`;
     options.width = 380;
     return options;
   }

--- a/src/module/dice.js
+++ b/src/module/dice.js
@@ -1,3 +1,5 @@
+import { OSE } from "./config";
+
 export class OseDice {
   static async sendRoll({
     parts = [],
@@ -8,7 +10,7 @@ export class OseDice {
     form = null,
     chatMessage = true,
   } = {}) {
-    const template = "systems/ose/dist/templates/chat/roll-result.html";
+    const template = `${OSE.systemPath}/templates/chat/roll-result.html`;
 
     let chatData = {
       user: game.user.id,
@@ -200,7 +202,7 @@ export class OseDice {
     speaker = null,
     form = null,
   } = {}) {
-    const template = "systems/ose/dist/templates/chat/roll-attack.html";
+    const template = `${OSE.systemPath}/templates/chat/roll-attack.html`;
     let chatData = {
       user: game.user.id,
       speaker: speaker,
@@ -299,7 +301,7 @@ export class OseDice {
     chatMessage = true,
   } = {}) {
     let rolled = false;
-    const template = "systems/ose/dist/templates/chat/roll-dialog.html";
+    const template = `${OSE.systemPath}/templates/chat/roll-dialog.html`;
     let dialogData = {
       formula: parts.join(" "),
       data: data,
@@ -377,7 +379,7 @@ export class OseDice {
     flags = {},
   } = {}) {
     let rolled = false;
-    const template = "systems/ose/dist/templates/chat/roll-dialog.html";
+    const template = `${OSE.systemPath}/templates/chat/roll-dialog.html`;
     let dialogData = {
       formula: parts.join(" "),
       data: data,

--- a/src/module/dice.js
+++ b/src/module/dice.js
@@ -10,7 +10,7 @@ export class OseDice {
     form = null,
     chatMessage = true,
   } = {}) {
-    const template = `${OSE.systemPath}/templates/chat/roll-result.html`;
+    const template = `${OSE.systemPath()}/templates/chat/roll-result.html`;
 
     let chatData = {
       user: game.user.id,
@@ -202,7 +202,7 @@ export class OseDice {
     speaker = null,
     form = null,
   } = {}) {
-    const template = `${OSE.systemPath}/templates/chat/roll-attack.html`;
+    const template = `${OSE.systemPath()}/templates/chat/roll-attack.html`;
     let chatData = {
       user: game.user.id,
       speaker: speaker,
@@ -301,7 +301,7 @@ export class OseDice {
     chatMessage = true,
   } = {}) {
     let rolled = false;
-    const template = `${OSE.systemPath}/templates/chat/roll-dialog.html`;
+    const template = `${OSE.systemPath()}/templates/chat/roll-dialog.html`;
     let dialogData = {
       formula: parts.join(" "),
       data: data,
@@ -379,7 +379,7 @@ export class OseDice {
     flags = {},
   } = {}) {
     let rolled = false;
-    const template = `${OSE.systemPath}/templates/chat/roll-dialog.html`;
+    const template = `${OSE.systemPath()}/templates/chat/roll-dialog.html`;
     let dialogData = {
       formula: parts.join(" "),
       data: data,

--- a/src/module/helpers.js
+++ b/src/module/helpers.js
@@ -60,6 +60,6 @@ export const registerHelpers = async function () {
   });
 
   Handlebars.registerHelper("path", function (relativePath) {
-    return `${OSE.systemPath}${relativePath}`;
+    return `${OSE.systemPath()}${relativePath}`;
   });
 };

--- a/src/module/helpers.js
+++ b/src/module/helpers.js
@@ -1,3 +1,5 @@
+import { OSE } from "./config";
+
 export const registerHelpers = async function () {
   // Handlebars template helpers
   Handlebars.registerHelper("eq", function (a, b) {
@@ -39,7 +41,9 @@ export const registerHelpers = async function () {
   });
 
   Handlebars.registerHelper("getTagIcon", function (tag) {
-    let idx = Object.keys(CONFIG.OSE.tags).find(k => (CONFIG.OSE.tags[k] == tag));
+    let idx = Object.keys(CONFIG.OSE.tags).find(
+      (k) => CONFIG.OSE.tags[k] == tag
+    );
     return CONFIG.OSE.tag_images[idx];
   });
 
@@ -49,10 +53,13 @@ export const registerHelpers = async function () {
       : Math.clamped(100 - (100.0 * value) / max, 0, 100);
   });
 
-  Handlebars.registerHelper('times', function (n, block) {
-    var accum = '';
-    for (let i = 0; i < n; ++i)
-      accum += block.fn(i);
+  Handlebars.registerHelper("times", function (n, block) {
+    var accum = "";
+    for (let i = 0; i < n; ++i) accum += block.fn(i);
     return accum;
+  });
+
+  Handlebars.registerHelper("path", function (relativePath) {
+    return `${OSE.systemPath}${relativePath}`;
   });
 };

--- a/src/module/item/entity.js
+++ b/src/module/item/entity.js
@@ -1,4 +1,4 @@
-import { OseDice } from "../dice.js";
+import { OseDice } from "../dice";
 
 /**
  * Override and extend the basic :class:`Item` implementation
@@ -151,9 +151,11 @@ export class OseItem extends Item {
 
   _getRollTag(data) {
     if (data.roll) {
-      const roll = `${data.roll}${data.rollTarget ? CONFIG.OSE.roll_type[data.rollType] : ""}${data.rollTarget ? data.rollTarget : ""}`;
+      const roll = `${data.roll}${
+        data.rollTarget ? CONFIG.OSE.roll_type[data.rollType] : ""
+      }${data.rollTarget ? data.rollTarget : ""}`;
       return {
-        label: `${game.i18n.localize("OSE.items.Roll")} ${roll}`
+        label: `${game.i18n.localize("OSE.items.Roll")} ${roll}`,
       };
     } else {
       return;

--- a/src/module/item/item-sheet.js
+++ b/src/module/item/item-sheet.js
@@ -1,3 +1,5 @@
+import { OSE } from "../config";
+
 /**
  * Extend the basic ItemSheet with some very simple modifications
  */
@@ -35,7 +37,7 @@ export class OseItemSheet extends ItemSheet {
 
   /** @override */
   get template() {
-    const path = "systems/ose/dist/templates/items/";
+    const path = `${OSE.systemPath}/templates/items/`;
     return `${path}/${this.item.data.type}-sheet.html`;
   }
 

--- a/src/module/item/item-sheet.js
+++ b/src/module/item/item-sheet.js
@@ -37,7 +37,7 @@ export class OseItemSheet extends ItemSheet {
 
   /** @override */
   get template() {
-    const path = `${OSE.systemPath}/templates/items/`;
+    const path = `${OSE.systemPath()}/templates/items/`;
     return `${path}/${this.item.data.type}-sheet.html`;
   }
 

--- a/src/module/party.js
+++ b/src/module/party.js
@@ -1,20 +1,22 @@
-import { OsePartySheet } from "./party/party-sheet.js";
+import { OsePartySheet } from "./party/party-sheet";
 
 export const addControl = (object, html) => {
-    let control = `<button class='ose-party-sheet' type="button" title='${game.i18n.localize('OSE.dialog.partysheet')}'><i class='fas fa-users'></i></button>`;
-    html.find(".fas.fa-search").replaceWith($(control));
-    html.find('.ose-party-sheet').click(ev => {
-        ev.preventDefault();
-        Hooks.call("OSE.Party.showSheet");
-    });
-}
+  let control = `<button class='ose-party-sheet' type="button" title='${game.i18n.localize(
+    "OSE.dialog.partysheet"
+  )}'><i class='fas fa-users'></i></button>`;
+  html.find(".fas.fa-search").replaceWith($(control));
+  html.find(".ose-party-sheet").click((ev) => {
+    ev.preventDefault();
+    Hooks.call("OSE.Party.showSheet");
+  });
+};
 
 export const update = (actor, data) => {
-    const partyFlag = actor.getFlag('ose', 'party');
+  const partyFlag = actor.getFlag("ose", "party");
 
-    if (partyFlag === null) {
-        return;
-    }
+  if (partyFlag === null) {
+    return;
+  }
 
-    OsePartySheet.partySheet.render();
-}
+  OsePartySheet.partySheet.render();
+};

--- a/src/module/party/party-sheet.js
+++ b/src/module/party/party-sheet.js
@@ -10,7 +10,7 @@ export class OsePartySheet extends FormApplication {
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
       classes: ["ose", "dialog", "party-sheet"],
-      template: `${OSE.systemPath}/templates/apps/party-sheet.html`,
+      template: `${OSE.systemPath()}/templates/apps/party-sheet.html`,
       width: 280,
       height: 400,
       resizable: true,

--- a/src/module/party/party-sheet.js
+++ b/src/module/party/party-sheet.js
@@ -1,21 +1,23 @@
-import { OsePartyXP } from "./party-xp.js";
-import { OseParty } from "./party.js";
+import { OsePartyXP } from "./party-xp";
+import { OseParty } from "./party";
+import { OSE } from "../config";
 
 const Party = {
-  partySheet: void 0
+  partySheet: void 0,
 };
 
 export class OsePartySheet extends FormApplication {
-
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
       classes: ["ose", "dialog", "party-sheet"],
-      template: "systems/ose/dist/templates/apps/party-sheet.html",
+      template: `${OSE.systemPath}/templates/apps/party-sheet.html`,
       width: 280,
       height: 400,
       resizable: true,
-      dragDrop: [{ dragSelector: ".actor-list .actor", dropSelector: ".party-members" }],
-      closeOnSubmit: false
+      dragDrop: [
+        { dragSelector: ".actor-list .actor", dropSelector: ".party-members" },
+      ],
+      closeOnSubmit: false,
     });
   }
 
@@ -104,14 +106,14 @@ export class OsePartySheet extends FormApplication {
     }
 
     const actors = game.actors;
-    let droppedActor = actors.find(actor => actor.id === data.id);
+    let droppedActor = actors.find((actor) => actor.id === data.id);
 
     this._addActorToParty(droppedActor);
   }
 
   _recursiveAddFolder(folder) {
-    folder.content.forEach(actor => this._addActorToParty(actor));
-    folder.children.forEach(folder => this._recursiveAddFolder(folder));
+    folder.content.forEach((actor) => this._addActorToParty(actor));
+    folder.children.forEach((folder) => this._recursiveAddFolder(folder));
   }
 
   _onDropFolder(event, data) {
@@ -132,7 +134,7 @@ export class OsePartySheet extends FormApplication {
 
       const dragData = {
         id: actorId,
-        type: "Actor"
+        type: "Actor",
       };
 
       // Set data transfer
@@ -154,21 +156,17 @@ export class OsePartySheet extends FormApplication {
   activateListeners(html) {
     super.activateListeners(html);
 
-    html
-      .find(".header #deal-xp")
-      .click(this._dealXP.bind(this));
+    html.find(".header #deal-xp").click(this._dealXP.bind(this));
 
     // Actor buttons
     const getActor = (event) => {
       const id = event.currentTarget.closest(".actor").dataset.actorId;
-      return game.actors.get(id)
+      return game.actors.get(id);
     };
 
-    html
-      .find(".field-img button[data-action='open-sheet']")
-      .click((event) => {
-        getActor(event).sheet.render(true);
-      });
+    html.find(".field-img button[data-action='open-sheet']").click((event) => {
+      getActor(event).sheet.render(true);
+    });
 
     html
       .find(".field-img button[data-action='remove-actor']")

--- a/src/module/party/party-xp.js
+++ b/src/module/party/party-xp.js
@@ -5,7 +5,7 @@ export class OsePartyXP extends FormApplication {
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
       classes: ["ose", "dialog", "party-xp"],
-      template: `${OSE.systemPath}/templates/apps/party-xp.html`,
+      template: `${OSE.systemPath()}/templates/apps/party-xp.html`,
       width: 300,
       height: "auto",
       resizable: false,

--- a/src/module/party/party-xp.js
+++ b/src/module/party/party-xp.js
@@ -1,14 +1,15 @@
-import { OseParty } from "./party.js";
+import { OseParty } from "./party";
+import { OSE } from "../config";
 
 export class OsePartyXP extends FormApplication {
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
       classes: ["ose", "dialog", "party-xp"],
-      template: "systems/ose/dist/templates/apps/party-xp.html",
+      template: `${OSE.systemPath}/templates/apps/party-xp.html`,
       width: 300,
       height: "auto",
       resizable: false,
-      closeOnSubmit: true
+      closeOnSubmit: true,
     });
   }
 
@@ -64,7 +65,9 @@ export class OsePartyXP extends FormApplication {
     const baseXpShare = parseFloat(totalXP) / currentParty.length;
 
     currentParty.forEach((a) => {
-      const xpShare = Math.floor((a.data.data.details.xp.share / 100) * baseXpShare)
+      const xpShare = Math.floor(
+        (a.data.data.details.xp.share / 100) * baseXpShare
+      );
       html.find(`li[data-actor-id='${a.id}'] input`).val(xpShare);
     });
   }
@@ -89,6 +92,8 @@ export class OsePartyXP extends FormApplication {
     const totalField = html.find('input[name="total"]');
     totalField.on("input", this._calculateShare.bind(this));
 
-    html.find('button[data-action="deal-xp"').click(event => { super.submit(event) });
+    html.find('button[data-action="deal-xp"').click((event) => {
+      super.submit(event);
+    });
   }
 }

--- a/src/module/preloadTemplates.js
+++ b/src/module/preloadTemplates.js
@@ -3,26 +3,26 @@ import { OSE } from "./config";
 export const preloadHandlebarsTemplates = async function () {
   const templatePaths = [
     //Character Sheets
-    `${OSE.systemPath}/templates/actors/character-sheet.html`,
-    `${OSE.systemPath}/templates/actors/monster-sheet.html`,
+    `${OSE.systemPath()}/templates/actors/character-sheet.html`,
+    `${OSE.systemPath()}/templates/actors/monster-sheet.html`,
 
     //Character Sheets Partials
-    `${OSE.systemPath}/templates/actors/partials/character-header.html`,
-    `${OSE.systemPath}/templates/actors/partials/character-attributes-tab.html`,
-    `${OSE.systemPath}/templates/actors/partials/character-abilities-tab.html`,
-    `${OSE.systemPath}/templates/actors/partials/character-spells-tab.html`,
-    `${OSE.systemPath}/templates/actors/partials/character-inventory-tab.html`,
-    `${OSE.systemPath}/templates/actors/partials/actor-item-summary.html`,
-    `${OSE.systemPath}/templates/actors/partials/character-notes-tab.html`,
-    `${OSE.systemPath}/templates/actors/partials/monster-header.html`,
-    `${OSE.systemPath}/templates/actors/partials/monster-attributes-tab.html`,
+    `${OSE.systemPath()}/templates/actors/partials/character-header.html`,
+    `${OSE.systemPath()}/templates/actors/partials/character-attributes-tab.html`,
+    `${OSE.systemPath()}/templates/actors/partials/character-abilities-tab.html`,
+    `${OSE.systemPath()}/templates/actors/partials/character-spells-tab.html`,
+    `${OSE.systemPath()}/templates/actors/partials/character-inventory-tab.html`,
+    `${OSE.systemPath()}/templates/actors/partials/actor-item-summary.html`,
+    `${OSE.systemPath()}/templates/actors/partials/character-notes-tab.html`,
+    `${OSE.systemPath()}/templates/actors/partials/monster-header.html`,
+    `${OSE.systemPath()}/templates/actors/partials/monster-attributes-tab.html`,
 
     // Item Display
-    `${OSE.systemPath}/templates/actors/partials/item-auto-tags-partial.html`,
+    `${OSE.systemPath()}/templates/actors/partials/item-auto-tags-partial.html`,
 
     // Party Sheet
-    `${OSE.systemPath}/templates/apps/party-sheet.html`,
-    `${OSE.systemPath}/templates/apps/party-xp.html`,
+    `${OSE.systemPath()}/templates/apps/party-sheet.html`,
+    `${OSE.systemPath()}/templates/apps/party-xp.html`,
   ];
   return loadTemplates(templatePaths);
 };

--- a/src/module/preloadTemplates.js
+++ b/src/module/preloadTemplates.js
@@ -1,26 +1,28 @@
+import { OSE } from "./config";
+
 export const preloadHandlebarsTemplates = async function () {
   const templatePaths = [
     //Character Sheets
-    "systems/ose/dist/templates/actors/character-sheet.html",
-    "systems/ose/dist/templates/actors/monster-sheet.html",
+    `${OSE.systemPath}/templates/actors/character-sheet.html`,
+    `${OSE.systemPath}/templates/actors/monster-sheet.html`,
 
     //Character Sheets Partials
-    "systems/ose/dist/templates/actors/partials/character-header.html",
-    "systems/ose/dist/templates/actors/partials/character-attributes-tab.html",
-    "systems/ose/dist/templates/actors/partials/character-abilities-tab.html",
-    "systems/ose/dist/templates/actors/partials/character-spells-tab.html",
-    "systems/ose/dist/templates/actors/partials/character-inventory-tab.html",
-    "systems/ose/dist/templates/actors/partials/actor-item-summary.html",
-    "systems/ose/dist/templates/actors/partials/character-notes-tab.html",
-    "systems/ose/dist/templates/actors/partials/monster-header.html",
-    "systems/ose/dist/templates/actors/partials/monster-attributes-tab.html",
+    `${OSE.systemPath}/templates/actors/partials/character-header.html`,
+    `${OSE.systemPath}/templates/actors/partials/character-attributes-tab.html`,
+    `${OSE.systemPath}/templates/actors/partials/character-abilities-tab.html`,
+    `${OSE.systemPath}/templates/actors/partials/character-spells-tab.html`,
+    `${OSE.systemPath}/templates/actors/partials/character-inventory-tab.html`,
+    `${OSE.systemPath}/templates/actors/partials/actor-item-summary.html`,
+    `${OSE.systemPath}/templates/actors/partials/character-notes-tab.html`,
+    `${OSE.systemPath}/templates/actors/partials/monster-header.html`,
+    `${OSE.systemPath}/templates/actors/partials/monster-attributes-tab.html`,
 
     // Item Display
-    "systems/ose/dist/templates/actors/partials/item-auto-tags-partial.html",
+    `${OSE.systemPath}/templates/actors/partials/item-auto-tags-partial.html`,
 
     // Party Sheet
-    "systems/ose/dist/templates/apps/party-sheet.html",
-    "systems/ose/dist/templates/apps/party-xp.html",
+    `${OSE.systemPath}/templates/apps/party-sheet.html`,
+    `${OSE.systemPath}/templates/apps/party-xp.html`,
   ];
   return loadTemplates(templatePaths);
 };

--- a/src/module/renderList.js
+++ b/src/module/renderList.js
@@ -1,4 +1,5 @@
 import { OseItem } from "./item/entity";
+import { OSE } from "./config";
 
 export const RenderCompendium = async function (object, html, d) {
   if (object.documentName != "Item") {
@@ -11,7 +12,12 @@ export const RenderCompendium = async function (object, html, d) {
     const id = render[i].dataset.documentId;
 
     const element = docs.filter((d) => d.id === id)[0];
-    const tagTemplate = $.parseHTML(await renderTemplate("systems/ose/dist/templates/actors/partials/item-auto-tags-partial.html", {tags: OseItem.prototype.getAutoTagList.call(element)}));
+    const tagTemplate = $.parseHTML(
+      await renderTemplate(
+        `${OSE.systemPath}/templates/actors/partials/item-auto-tags-partial.html`,
+        { tags: OseItem.prototype.getAutoTagList.call(element) }
+      )
+    );
 
     $(item).append(tagTemplate);
   });
@@ -21,17 +27,21 @@ export const RenderDirectory = async function (object, html) {
   if (object.id != "items") {
     return;
   }
-  
+
   const render = html[0].querySelectorAll(".item");
   const content = object.documents;
 
   render.forEach(async function (item) {
-
     const foundryDocument = content.find(
       (e) => e.id == item.dataset.documentId
     );
 
-    const tagTemplate = $.parseHTML(await renderTemplate("systems/ose/dist/templates/actors/partials/item-auto-tags-partial.html", {tags: OseItem.prototype.getAutoTagList.call(foundryDocument)}));
+    const tagTemplate = $.parseHTML(
+      await renderTemplate(
+        `${OSE.systemPath}/templates/actors/partials/item-auto-tags-partial.html`,
+        { tags: OseItem.prototype.getAutoTagList.call(foundryDocument) }
+      )
+    );
     $(item).append(tagTemplate);
   });
 };

--- a/src/module/renderList.js
+++ b/src/module/renderList.js
@@ -14,7 +14,7 @@ export const RenderCompendium = async function (object, html, d) {
     const element = docs.filter((d) => d.id === id)[0];
     const tagTemplate = $.parseHTML(
       await renderTemplate(
-        `${OSE.systemPath}/templates/actors/partials/item-auto-tags-partial.html`,
+        `${OSE.systemPath()}/templates/actors/partials/item-auto-tags-partial.html`,
         { tags: OseItem.prototype.getAutoTagList.call(element) }
       )
     );
@@ -38,7 +38,7 @@ export const RenderDirectory = async function (object, html) {
 
     const tagTemplate = $.parseHTML(
       await renderTemplate(
-        `${OSE.systemPath}/templates/actors/partials/item-auto-tags-partial.html`,
+        `${OSE.systemPath()}/templates/actors/partials/item-auto-tags-partial.html`,
         { tags: OseItem.prototype.getAutoTagList.call(foundryDocument) }
       )
     );

--- a/src/module/treasure.js
+++ b/src/module/treasure.js
@@ -103,7 +103,7 @@ async function rollTreasure(table, options = {}) {
   }
 
   let html = await renderTemplate(
-    `${OSE.systemPath}/templates/chat/roll-treasure.html`,
+    `${OSE.systemPath()}/templates/chat/roll-treasure.html`,
     templateData
   );
 

--- a/src/module/treasure.js
+++ b/src/module/treasure.js
@@ -1,8 +1,12 @@
+import { OSE } from "./config";
+
 export const augmentTable = (table, html, data) => {
   // Treasure Toggle
   const isTreasureTable = Boolean(table.object.getFlag("ose", "treasure"));
 
-  let treasureTableToggle = $("<div class='toggle-treasure' title='Toggle Treasure Table'></div>");
+  let treasureTableToggle = $(
+    "<div class='toggle-treasure' title='Toggle Treasure Table'></div>"
+  );
   treasureTableToggle.toggleClass("active", isTreasureTable);
 
   let head = html.find(".sheet-header");
@@ -15,7 +19,7 @@ export const augmentTable = (table, html, data) => {
 
   // Treasure table formatting
   if (!isTreasureTable) {
-    return
+    return;
   }
 
   // Hide irrelevant standard fields
@@ -33,7 +37,9 @@ export const augmentTable = (table, html, data) => {
   formula.attr("disabled", true);
 
   // Replace Roll button
-  const roll = `<button class="roll-treasure" type="button"><i class="fas fa-gem"></i> ${game.i18n.localize("OSE.table.treasure.roll")}</button>`;
+  const roll = `<button class="roll-treasure" type="button"><i class="fas fa-gem"></i> ${game.i18n.localize(
+    "OSE.table.treasure.roll"
+  )}</button>`;
   html.find(".sheet-footer .roll").replaceWith(roll);
 
   html.find(".roll-treasure").click((ev) => {
@@ -97,7 +103,7 @@ async function rollTreasure(table, options = {}) {
   }
 
   let html = await renderTemplate(
-    "systems/ose/dist/templates/chat/roll-treasure.html",
+    `${OSE.systemPath}/templates/chat/roll-treasure.html`,
     templateData
   );
 

--- a/src/ose.js
+++ b/src/ose.js
@@ -124,7 +124,7 @@ Hooks.on("renderSidebarTab", async (object, html) => {
     );
 
     // License text
-    const template = `${OSE.systemPath}/templates/chat/license.html`;
+    const template = `${OSE.systemPath()}/templates/chat/license.html`;
     const rendered = await renderTemplate(template);
     gamesystem.find(".system").append(rendered);
 

--- a/src/ose.js
+++ b/src/ose.js
@@ -124,7 +124,7 @@ Hooks.on("renderSidebarTab", async (object, html) => {
     );
 
     // License text
-    const template = "systems/ose/dist/templates/chat/license.html";
+    const template = `${OSE.systemPath}/templates/chat/license.html`;
     const rendered = await renderTemplate(template);
     gamesystem.find(".system").append(rendered);
 

--- a/src/templates/actors/character-sheet.html
+++ b/src/templates/actors/character-sheet.html
@@ -1,7 +1,7 @@
 <form class="{{cssClass}}" autocomplete="off">
   {{! Sheet Header }}
   <header class="sheet-header flexrow">
-    {{> "systems/ose/dist/templates/actors/partials/character-header.html"}}
+    {{> (path "/templates/actors/partials/character-header.html") }}
   </header>
 
   {{! Sheet Tab Navigation }}
@@ -24,26 +24,21 @@
   <section class="sheet-body">
     {{! Attributes Tab }}
     <div class="tab" data-group="primary" data-tab="attributes">
-      {{>
-      "systems/ose/dist/templates/actors/partials/character-attributes-tab.html"}}
+      {{> (path "/templates/actors/partials/character-attributes-tab.html") }}
     </div>
     <div class="tab" data-group="primary" data-tab="abilities">
-      {{>
-      "systems/ose/dist/templates/actors/partials/character-abilities-tab.html"}}
+      {{> (path "/templates/actors/partials/character-abilities-tab.html") }}
     </div>
     {{#if data.spells.enabled}}
     <div class="tab" data-group="primary" data-tab="spells">
-      {{>
-      "systems/ose/dist/templates/actors/partials/character-spells-tab.html"}}
+      {{> (path "/templates/actors/partials/character-spells-tab.html") }}
     </div>
     {{/if}}
     <div class="tab" data-group="primary" data-tab="inventory">
-      {{>
-      "systems/ose/dist/templates/actors/partials/character-inventory-tab.html"}}
+      {{> (path "/templates/actors/partials/character-inventory-tab.html") }}
     </div>
     <div class="tab" data-group="primary" data-tab="notes">
-      {{>
-      "systems/ose/dist/templates/actors/partials/character-notes-tab.html"}}
+      {{> (path "/templates/actors/partials/character-notes-tab.html") }}
     </div>
   </section>
 </form>

--- a/src/templates/actors/monster-sheet.html
+++ b/src/templates/actors/monster-sheet.html
@@ -1,7 +1,7 @@
 <form class="{{cssClass}}" autocomplete="off">
   {{! Sheet Header }}
   <header class="sheet-header flexrow">
-    {{> "systems/ose/dist/templates/actors/partials/monster-header.html"}}
+    {{> (path "/templates/actors/partials/monster-header.html") }}
   </header>
 
   {{! Sheet Tab Navigation }}
@@ -22,18 +22,15 @@
   <section class="sheet-body">
     {{! Attributes Tab }}
     <div class="tab" data-group="primary" data-tab="attributes">
-      {{>
-      "systems/ose/dist/templates/actors/partials/monster-attributes-tab.html"}}
+      {{> (path "/templates/actors/partials/monster-attributes-tab.html") }}
     </div>
     {{#if data.config.enableInventory}}
     <div class="tab" data-group="primary" data-tab="inventory">
-      {{>
-      "systems/ose/dist/templates/actors/partials/character-inventory-tab.html"}}
+      {{> (path "/templates/actors/partials/character-inventory-tab.html") }}
     </div>
     {{/if}} {{#if data.spells.enabled}}
     <div class="tab" data-group="primary" data-tab="spells">
-      {{>
-      "systems/ose/dist/templates/actors/partials/character-spells-tab.html"}}
+      {{> (path "/templates/actors/partials/character-spells-tab.html") }}
     </div>
     {{/if}}
     <div class="tab" data-group="primary" data-tab="notes">

--- a/src/templates/actors/partials/actor-item-summary.html
+++ b/src/templates/actors/partials/actor-item-summary.html
@@ -1,4 +1,5 @@
 <div class="item-description">
-  {{> "systems/ose/dist/templates/actors/partials/item-auto-tags-partial.html" tags=item.data.data.autoTags}}
+  {{> (path "/templates/actors/partials/item-auto-tags-partial.html")
+  tags=item.data.data.autoTags}}
   <div>{{{item.data.data.description}}}</div>
 </div>

--- a/src/templates/actors/partials/character-abilities-tab.html
+++ b/src/templates/actors/partials/character-abilities-tab.html
@@ -1,41 +1,70 @@
 <ul class="attributes exploration flexrow">
   <li class="attribute flexrow" data-exploration="ld">
-    <h4 class="attribute-name box-title"
-      title="({{localize 'OSE.exploration.ld.abrev'}}) {{localize 'OSE.exploration.ld.long'}}"><a>{{ localize
-        "OSE.exploration.ld.short" }}</a></h4>
+    <h4
+      class="attribute-name box-title"
+      title="({{localize 'OSE.exploration.ld.abrev'}}) {{localize 'OSE.exploration.ld.long'}}"
+    >
+      <a>{{ localize "OSE.exploration.ld.short" }}</a>
+    </h4>
     <div class="attribute-value">
-      <input name="data.exploration.ld" type="text" value="{{data.exploration.ld}}" data-dtype="Number"
-        placeholder="0" />
+      <input
+        name="data.exploration.ld"
+        type="text"
+        value="{{data.exploration.ld}}"
+        data-dtype="Number"
+        placeholder="0"
+      />
     </div>
   </li>
   <li class="attribute flexrow" data-exploration="od">
-    <h4 class="attribute-name box-title"
-      title="({{localize 'OSE.exploration.od.abrev'}}) {{localize 'OSE.exploration.od.long'}}"><a>{{ localize
-        "OSE.exploration.od.short" }}</a>
+    <h4
+      class="attribute-name box-title"
+      title="({{localize 'OSE.exploration.od.abrev'}}) {{localize 'OSE.exploration.od.long'}}"
+    >
+      <a>{{ localize "OSE.exploration.od.short" }}</a>
     </h4>
     <div class="attribute-value">
-      <input name="data.exploration.od" type="text" value="{{data.exploration.od}}" placeholder="0"
-        data-dtype="String" />
+      <input
+        name="data.exploration.od"
+        type="text"
+        value="{{data.exploration.od}}"
+        placeholder="0"
+        data-dtype="String"
+      />
     </div>
   </li>
   <li class="attribute flexrow" data-exploration="sd">
-    <h4 class="attribute-name box-title"
-      title="({{localize 'OSE.exploration.sd.abrev'}}) {{localize 'OSE.exploration.sd.long'}}"><a>{{ localize
-        "OSE.exploration.sd.short" }}</a>
+    <h4
+      class="attribute-name box-title"
+      title="({{localize 'OSE.exploration.sd.abrev'}}) {{localize 'OSE.exploration.sd.long'}}"
+    >
+      <a>{{ localize "OSE.exploration.sd.short" }}</a>
     </h4>
     <div class="attribute-value">
-      <input name="data.exploration.sd" type="text" value="{{data.exploration.sd}}" placeholder="0"
-        data-dtype="String" />
+      <input
+        name="data.exploration.sd"
+        type="text"
+        value="{{data.exploration.sd}}"
+        placeholder="0"
+        data-dtype="String"
+      />
     </div>
   </li>
   <li class="attribute flexrow" data-exploration="ft">
-    <h4 class="attribute-name box-title"
-      title="({{localize 'OSE.exploration.ft.abrev'}}) {{localize 'OSE.exploration.ft.long'}}"><a>{{ localize
-        "OSE.exploration.ft.short" }}</a>
+    <h4
+      class="attribute-name box-title"
+      title="({{localize 'OSE.exploration.ft.abrev'}}) {{localize 'OSE.exploration.ft.long'}}"
+    >
+      <a>{{ localize "OSE.exploration.ft.short" }}</a>
     </h4>
     <div class="attribute-value">
-      <input name="data.exploration.ft" type="text" value="{{data.exploration.ft}}" placeholder="0"
-        data-dtype="String" />
+      <input
+        name="data.exploration.ft"
+        type="text"
+        value="{{data.exploration.ft}}"
+        placeholder="0"
+        data-dtype="String"
+      />
     </div>
   </li>
 </ul>
@@ -44,29 +73,43 @@
     <div class="category-name">{{localize 'OSE.category.abilities'}}</div>
     <div class="item-controls">
       {{#if owner}}
-      <a class="item-control item-create" title='{{localize "OSE.Add"}}' data-type="ability"><i
-          class="fas fa-plus"></i></a>
+      <a
+        class="item-control item-create"
+        title='{{localize "OSE.Add"}}'
+        data-type="ability"
+        ><i class="fas fa-plus"></i
+      ></a>
       {{/if}}
     </div>
   </div>
   <ol class="item-list resizable" data-base-size="260">
     {{#each abilities as |item|}}
     <li class="item-entry item" data-item-id="{{item.id}}">
-      <div class="item-header flexrow {{#if item.data.data.roll}}item-rollable{{/if}}">
-        <div class="item-image" style="background-image: url({{item.img}})"></div>
-        <h4 class="item-name" title="{{item.name}}">
-          {{item.name~}}
-        </h4>
+      <div
+        class="item-header flexrow {{#if item.data.data.roll}}item-rollable{{/if}}"
+      >
+        <div
+          class="item-image"
+          style="background-image: url({{item.img}})"
+        ></div>
+        <h4 class="item-name" title="{{item.name}}">{{item.name~}}</h4>
         <div class="item-controls">
           {{#if ../owner}}
-          <a class="item-control item-show" title='{{localize "OSE.Show"}}'><i class="fas fa-eye"></i></a>
-          <a class="item-control item-edit" title='{{localize "OSE.Edit"}}'><i class="fas fa-edit"></i></a>
-          <a class="item-control item-delete" title='{{localize "OSE.Delete"}}'><i class="fas fa-trash"></i></a>
+          <a class="item-control item-show" title='{{localize "OSE.Show"}}'
+            ><i class="fas fa-eye"></i
+          ></a>
+          <a class="item-control item-edit" title='{{localize "OSE.Edit"}}'
+            ><i class="fas fa-edit"></i
+          ></a>
+          <a class="item-control item-delete" title='{{localize "OSE.Delete"}}'
+            ><i class="fas fa-trash"></i
+          ></a>
           {{/if}}
         </div>
       </div>
       <div class="item-summary">
-        {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=item}}
+        {{> (path "/templates/actors/partials/actor-item-summary.html")
+        item=item}}
       </div>
     </li>
     {{/each}}

--- a/src/templates/actors/partials/character-inventory-tab.html
+++ b/src/templates/actors/partials/character-inventory-tab.html
@@ -62,7 +62,7 @@
         </div>
       </div>
       <div class="item-summary">
-        {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html"
+        {{> (path "/templates/actors/partials/actor-item-summary.html")
         item=item}}
       </div>
     </li>
@@ -122,7 +122,7 @@
         </div>
       </div>
       <div class="item-summary">
-        {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html"
+        {{> (path "/templates/actors/partials/actor-item-summary.html")
         item=item}}
       </div>
     </li>
@@ -175,7 +175,7 @@
         </div>
       </div>
       <div class="item-summary">
-        {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html"
+        {{> (path "/templates/actors/partials/actor-item-summary.html")
         item=bag}}
       </div>
       <ol class="item-list contained-items">
@@ -229,8 +229,7 @@
           </div>
           {{/if}} {{/if}}
           <div class="item-summary">
-            {{>
-            "systems/ose/dist/templates/actors/partials/actor-item-summary.html"
+            {{> (path "/templates/actors/partials/actor-item-summary.html")
             item=item}}
           </div>
         </li>
@@ -301,7 +300,7 @@
       </div>
       {{/if}} {{/if}}
       <div class="item-summary">
-        {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html"
+        {{> (path "/templates/actors/partials/actor-item-summary.html")
         item=item}}
       </div>
     </li>
@@ -364,7 +363,7 @@
         </div>
       </div>
       <div class="item-summary">
-        {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html"
+        {{> (path "/templates/actors/partials/actor-item-summary.html")
         item=item}}
       </div>
     </li>

--- a/src/templates/actors/partials/character-spells-tab.html
+++ b/src/templates/actors/partials/character-spells-tab.html
@@ -1,54 +1,99 @@
 <section class="inventory spells resizable" data-base-size="320">
-  <div class="item-category-title flexrow" style="line-height:15px">
+  <div class="item-category-title flexrow" style="line-height: 15px">
     <div class="category-name">{{localize "OSE.category.spells"}}</div>
     <div class="item-controls">
-      <a class="item-control item-reset" title='{{localize "OSE.spells.ResetSlots"}}' data-action="reset-spells"><i
-          class="fas fa-sync"></i></a>
-      <a class="item-control item-create" data-type="spell" title="{{localize 'OSE.Add'}}"><i
-          class="fa fa-plus"></i></a>
+      <a
+        class="item-control item-reset"
+        title='{{localize "OSE.spells.ResetSlots"}}'
+        data-action="reset-spells"
+        ><i class="fas fa-sync"></i
+      ></a>
+      <a
+        class="item-control item-create"
+        data-type="spell"
+        title="{{localize 'OSE.Add'}}"
+        ><i class="fa fa-plus"></i
+      ></a>
     </div>
   </div>
   {{#each spells as |spellGroup id|}}
   <div class="item-category-title flexrow">
-    <div class="category-caret"><i class="fas fa-caret-down"></i> </div>
+    <div class="category-caret"><i class="fas fa-caret-down"></i></div>
     <div class="category-name">{{localize "OSE.spells.Level"}} {{id}}</div>
     <div class="field-short">{{localize 'OSE.spells.Slots'}}</div>
     <div class="field-long flexrow">
-      <input type="text" value="{{lookup @root.slots.used @key}}" name="data.spells.{{id}}.value" data-dtype="Number"
-        placeholder="0" disabled title="{{localize 'OSE.spells.MemorizedSlotsHint'}}">/<input type="text"
-        value="{{lookup (lookup @root.data.spells @key) 'max'}}" name="data.spells.{{id}}.max" data-dtype="Number"
-        placeholder="0" title="{{localize 'OSE.spells.MaximumSlotsHint'}}">
+      <input
+        type="text"
+        value="{{lookup @root.slots.used @key}}"
+        name="data.spells.{{id}}.value"
+        data-dtype="Number"
+        placeholder="0"
+        disabled
+        title="{{localize 'OSE.spells.MemorizedSlotsHint'}}"
+      />/<input
+        type="text"
+        value="{{lookup (lookup @root.data.spells @key) 'max'}}"
+        name="data.spells.{{id}}.max"
+        data-dtype="Number"
+        placeholder="0"
+        title="{{localize 'OSE.spells.MaximumSlotsHint'}}"
+      />
     </div>
     <div class="item-controls">
-      <a class="item-control item-create" data-type="spell" data-lvl="{{id}}" title="{{localize 'OSE.Add'}}"><i
-          class="fa fa-plus"></i></a>
+      <a
+        class="item-control item-create"
+        data-type="spell"
+        data-lvl="{{id}}"
+        title="{{localize 'OSE.Add'}}"
+        ><i class="fa fa-plus"></i
+      ></a>
     </div>
   </div>
   <ol class="item-list">
     {{#each spellGroup as |item|}}
     <li class="item-entry item" data-item-id="{{item.id}}">
       <div class="item-header flexrow item-rollable">
-        <div class="item-image" style="background-image: url({{item.img}})"></div>
-        <h4 class="item-name" title="{{item.name}}">
-          {{item.name~}}
-        </h4>
+        <div
+          class="item-image"
+          style="background-image: url({{item.img}})"
+        ></div>
+        <h4 class="item-name" title="{{item.name}}">{{item.name~}}</h4>
         <div class="field-long memorize flexrow">
-          <input type="text" value="{{item.data.data.cast}}" data-dtype="Number" placeholder="0" data-field="cast"
-            title="{{localize 'OSE.spells.Cast'}}">
+          <input
+            type="text"
+            value="{{item.data.data.cast}}"
+            data-dtype="Number"
+            placeholder="0"
+            data-field="cast"
+            title="{{localize 'OSE.spells.Cast'}}"
+          />
           /
-          <input type="text" value="{{item.data.data.memorized}}" data-field="memorize" data-dtype="Number"
-            placeholder="0" title="{{localize 'OSE.spells.Memorized'}}">
+          <input
+            type="text"
+            value="{{item.data.data.memorized}}"
+            data-field="memorize"
+            data-dtype="Number"
+            placeholder="0"
+            title="{{localize 'OSE.spells.Memorized'}}"
+          />
         </div>
         <div class="item-controls">
           {{#if ../../owner}}
-          <a class="item-control item-show" title='{{localize "OSE.Show"}}'><i class="fas fa-eye"></i></a>
-          <a class="item-control item-edit" title='{{localize "OSE.Edit"}}'><i class="fas fa-edit"></i></a>
-          <a class="item-control item-delete" title='{{localize "OSE.Delete"}}'><i class="fas fa-trash"></i></a>
+          <a class="item-control item-show" title='{{localize "OSE.Show"}}'
+            ><i class="fas fa-eye"></i
+          ></a>
+          <a class="item-control item-edit" title='{{localize "OSE.Edit"}}'
+            ><i class="fas fa-edit"></i
+          ></a>
+          <a class="item-control item-delete" title='{{localize "OSE.Delete"}}'
+            ><i class="fas fa-trash"></i
+          ></a>
           {{/if}}
         </div>
       </div>
       <div class="item-summary">
-        {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=item}}
+        {{> (path "/templates/actors/partials/actor-item-summary.html")
+        item=item}}
       </div>
     </li>
     {{/each}}

--- a/src/templates/actors/partials/monster-attributes-tab.html
+++ b/src/templates/actors/partials/monster-attributes-tab.html
@@ -131,7 +131,7 @@
                             </div>
                         </div>
                         <div class="item-summary">
-                            {{> "systems/ose/dist/templates/actors/partials/actor-item-summary.html" item=item}}
+                            {{> (path "/templates/actors/partials/actor-item-summary.html") item=item}}
                         </div>
                     </li>
                     {{/each}}


### PR DESCRIPTION
#154 had a problem where if you were using a symbolic link prefix, the path wasn't resolving correctly for templates. This creates a helper function for handlebars to check the current system's id and use that in the full path