### PR TITLE
actor sheet inline roll render fix

### DIFF
--- a/src/module/helpers.js
+++ b/src/module/helpers.js
@@ -62,4 +62,9 @@ export const registerHelpers = async function () {
   Handlebars.registerHelper("path", function (relativePath) {
     return `${OSE.systemPath()}${relativePath}`;
   });
+
+  // helper for parsing inline rolls
+  Handlebars.registerHelper("parseInline", function (html) {
+    return TextEditor.enrichHTML(html)
+  })
 };

--- a/src/templates/actors/partials/actor-item-summary.html
+++ b/src/templates/actors/partials/actor-item-summary.html
@@ -1,5 +1,5 @@
 <div class="item-description">
   {{> (path "/templates/actors/partials/item-auto-tags-partial.html")
   tags=item.data.data.autoTags}}
-  <div>{{{item.data.data.description}}}</div>
+  <div>{{{parseInline item.data.data.description}}}</div>
 </div>


### PR DESCRIPTION
Added a new handlebars helper that returns enriched HTML.
Changed template partial actor-item-summary to use the new helper to enrich item summary display text.
This fixes actor item summaries failure to display inline rolls correctly.