### PR TITLE
Issue #35: monster abilities and equipment sort order rework

### DIFF
--- a/template.json
+++ b/template.json
@@ -225,7 +225,7 @@
     },
     "ability": {
       "templates": ["common", "rollable"],
-      "pattern": "white",
+      "pattern": "transparent",
       "requirements": "",
       "roll": "",
       "rollType": "result",


### PR DESCRIPTION
This PR addresses https://github.com/vttred/ose/issues/35
* For monsters, sort Abilities & Equipment by attack pattern, then weapons before abilities, then alphabetical.  
*Sort inventory and spells alphabetically within groups.
* Set ability default attack pattern to transparent (was white), 
* include transparent in attack pattern cycling

This is my first PR here and I am not experienced with javascript, so any suggestions for improvements are welcome!