### PR TITLE
Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,87 @@
+name: Bug Report
+description: File a bug report
+title: ""
+labels: ["bug", "triage"]
+assignees:
+  - anthonyronda
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Give us the details of the steps taken, and the unexpected result you experienced.
+      placeholder: |
+        Reproduction steps:
+        1. I clicked the token.
+        2. The token jumped across the scene 10 spaces to the left.
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behaviour
+    attributes:
+      label: What is the expected behaviour?
+      description: If this is a bug, what would you expect the fix to do?
+      placeholder: |
+        When I click the token, it becomes selected and stays in its current position.
+  - type: dropdown
+    id: core-version
+    attributes:
+      label: Foundry VTT Core Version
+      description: Which version of Foundry VTT is installed?
+      options:
+        - V10
+        - V9
+        - 0.8.6-0.8.10
+        - Earlier than 0.8.6
+  - type: input
+    id: system-version
+    attributes:
+      label: Old-School Essentials Core Version
+      description: Which version of Old-School Essentials Foundry VTT Edition are you using?
+    validations:
+      required: true
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: Which (updated) browsers are you seeing the problem on?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+        - Other
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Errors and Warnings
+      description: Is there an error message or warning in the browser console when you experienced this behaviour? Press F12, copy anything relevant, and paste it here.
+      render: shell
+  - type: textarea
+    id: debug
+    attributes:
+      label: Additional Support Details
+      description: With your Foundry VTT game active, you may click the Game Settings tab, then click the Support button. Please copy the debug information and paste it below.
+      placeholder: |
+        Foundry Virtual Tabletop: Version 9, 9.269
+        Game System: ose, 1.5.1
+        Active Modules: 9
+        Performance Mode: 1
+
+        OS: Intel Mac OS X 10.15
+        Client: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:103.0) Gecko/20100101 Firefox/103.0
+        GPU: Apple M1
+        Max Texture Size: 8192
+        ...
+  - type: checkboxes
+    id: code-of-conduct
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/vttred/.github/blob/main/CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: File a bug report
-title: ""
 labels: ["bug", "triage"]
 assignees:
   - anthonyronda

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -26,39 +26,11 @@ body:
       description: If this is a bug, what would you expect the fix to do?
       placeholder: |
         When I click the token, it becomes selected and stays in its current position.
-  - type: dropdown
-    id: core-version
-    attributes:
-      label: Foundry VTT Core Version
-      description: Which version of Foundry VTT is installed?
-      options:
-        - V10
-        - V9
-        - 0.8.6-0.8.10
-        - Earlier than 0.8.6
-  - type: input
-    id: system-version
-    attributes:
-      label: Old-School Essentials Core Version
-      description: Which version of Old-School Essentials Foundry VTT Edition are you using?
-    validations:
-      required: true
-  - type: dropdown
-    id: browsers
-    attributes:
-      label: Which (updated) browsers are you seeing the problem on?
-      multiple: true
-      options:
-        - Firefox
-        - Chrome
-        - Safari
-        - Microsoft Edge
-        - Other
   - type: textarea
     id: logs
     attributes:
       label: Relevant Errors and Warnings
-      description: Is there an error message or warning in the browser console when you experienced this behaviour? Press F12, copy anything relevant, and paste it here.
+      description: Is there an error message or warning in the browser console when you experienced this behaviour? Right after triggering the bug, press F12 and copy anything relevant in the console window. Paste that here.
       render: shell
   - type: textarea
     id: debug
@@ -76,6 +48,32 @@ body:
         GPU: Apple M1
         Max Texture Size: 8192
         ...
+  - type: dropdown
+    id: core-version
+    attributes:
+      label: Foundry VTT Core Version
+      description: Which version of Foundry VTT is installed? Skip this if you provided Additional Support Details.
+      options:
+        - V10
+        - V9
+        - 0.8.6-0.8.10
+        - Earlier than 0.8.6
+  - type: input
+    id: system-version
+    attributes:
+      label: Old-School Essentials Core Version
+      description: Which version of Old-School Essentials Foundry VTT Edition are you using? Skip this if you provided Additional Support Details.
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: Please update your browser regularly. Which (updated) browsers are you seeing the problem on?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+        - Other
   - type: checkboxes
     id: code-of-conduct
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: User Documentation
+    url: https://vtt.red/ose
+    about: Learn how to get started with Old-School Essentials on Foundry VTT.
+  - name: Old-School Essentials FVTT Edition Discord Community
+    url: https://github.com/orgs/community/discussions
+    about: Ask a question in our \#foundryvtt-help channel.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: true
 contact_links:
   - name: User Documentation
     url: https://vtt.red/ose
-    about: Learn how to get started with Old-School Essentials on Foundry VTT.
+    about: "Learn how to get started with Old-School Essentials on Foundry VTT."
   - name: Old-School Essentials FVTT Edition Discord Community
     url: https://github.com/orgs/community/discussions
-    about: Ask a question in our \#foundryvtt-help channel.
+    about: "Ask a question in our #foundryvtt-help channel."

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://vtt.red/ose
     about: "Learn how to get started with Old-School Essentials on Foundry VTT."
   - name: Old-School Essentials FVTT Edition Discord Community
-    url: https://github.com/orgs/community/discussions
+    url: https://discord.gg/y6RM86YgNY
     about: "Ask a question in our #foundryvtt-help channel."

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,33 @@
+name: Enhancement Request
+description: Request a new feature or improvement to the current functionality.
+title: ""
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this enhancement request!
+  - type: textarea
+    id: new-behaviour
+    attributes:
+      label: New Feature or Changed Behaviour
+      description: Describe your proposed enhancement in detail, and provide examples.
+      placeholder: |
+        Example: Create a new character sheet field called "Race" which automatically changes the naked AC based on the race chosen.
+    validations:
+      required: true
+  - type: textarea
+    id: explanation-of-change
+    attributes:
+      label: Why?
+      description: Would this improve/shorten a player's workflow? Would this be more intuitive? Explain with details and examples.
+      placeholder: |
+        Players will be able to make AC modifications without having to use Tweaks, saving them time and removing an extra field from the Tweaks menu.
+  - type: checkboxes
+    id: code-of-conduct
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/vttred/.github/blob/main/CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,6 +1,5 @@
 name: Enhancement Request
 description: Request a new feature or improvement to the current functionality.
-title: ""
 labels: ["enhancement"]
 body:
   - type: markdown

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
   </a>
 </p>
 <h1 align="center">
-  Unofficial Old-School Essentials on Foundry VTT
+  Old-School Essentials – Foundry VTT Edition
 </h1>
 <p align="center">
-  <!-- BEGIN TEXT REQUIRED BY LICENSE -->Requires <strong><em>Old-School Essentials</em></strong>.<!-- END TEXT REQUIRED BY LICENSE --> Find the game at <a href="https://necroticgnome.com">Necrotic Gnome's website</a>.
+  <!-- BEGIN TEXT REQUIRED BY LICENSE -->Requires <strong><em>Old-School Essentials</em></strong> Classic Fantasy or Advanced Fantasy.<!-- END TEXT REQUIRED BY LICENSE --> Find the game at <a href="https://necroticgnome.com">Necrotic Gnome's website</a>.
 </p>
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
@@ -36,13 +36,18 @@ https://github.com/vttred/ose-content/releases/latest/download/module.json
 
 ## Your Support
 
-If you use this system and appreciate it, we're not asking for your financial support at this time. Here's a couple free things you can do instead.
+If you use this system and want to show your appreciation, here's a couple free things you can do.
 
-- If you're a GitHub user and you appreciate this system, please give us a GitHub Star.
+- If you're a GitHub user, please give us a GitHub star.
 - If you're a Foundry Hub user, please [endorse us or write a comment](https://www.foundryvtt-hub.com/package/ose/) (happy feedback and constructive feedback appreciated).
-- If you speak a non-English language, contribute some of your time on a system translation. [Join the ose project on Crowdin](https://crowdin.com/project/ose).
-- If you speak JavaScript, consider [contributing code](/CONTRIBUTING.md).
+- If you speak a non-English language fluently, please contribute some of your time on an open source translation. [Join the ose project on Crowdin](https://crowdin.com/project/ose).
+- If you speak JavaScript, please consider [contributing code](/CONTRIBUTING.md).
+
+Here's a couple paid things you can do.
+
 - If you'd like to support the original maintainer of this system, U\~man, buy them a coffee on [Ko-Fi](https://ko-fi.com/u_man). It is largely because of U\~man's generosity that we are able to continue providing a free and open source system for Foundry VTT users.
+- Official Necrotic Gnome Foundry VTT Editions support the maintainence of the codebase. For official announcements, follow the [Necrotic Gnome blog or subscribe to their newsletter](https://necroticgnome.com/blogs/newsletter-archive).
+- Third-party releases may support one or more of our open source contributors. Find out more on our [website](https://vtt.red/ose).
 
 ## Troubleshooting and Requesting User Support
 


### PR DESCRIPTION
Introducing issue templates makes it easier for less experienced users to submit useful issues for their first time, hopefully increasing the number of issues we receive.

Providing the links to docs and the Discord server in the issues tab hopefully improves the number of people providing feedback on docs and joining the Discord server to ask relevant questions.