### PR TITLE
chore: migrate to "ose-dev" package name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           files: "system.json"
         env:
+          name: ose
+          id: ose
+          title: "Old-School Essentials"
           version: ${{github.event.release.tag_name}}
           url: https://github.com/${{github.repository}}
           manifest: https://github.com/${{github.repository}}/releases/latest/download/system.json

--- a/system.json
+++ b/system.json
@@ -1,7 +1,7 @@
 {
-  "name": "ose",
-  "id": "ose",
-  "title": "Old-School Essentials",
+  "name": "ose-dev",
+  "id": "ose-dev",
+  "title": "Old-School Essentials Development Build",
   "description": "Play B/X OSR modules with Old-School Essentials on Foundry VTT",
   "version": "AUTOMATICALLY REPLACED BY GITHUB WORKFLOW ACTION",
   "minimumCoreVersion": "10",


### PR DESCRIPTION
system.json will now show

```
name: "ose-dev",
id: "ose-dev",
title: "Old-School Essentials Development Build",
```

Please update your symlinks to match the new name