### PR TITLE
Add a placeholder text to the Party overview when empty

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -13,6 +13,7 @@
 
   "OSE.dialog.tweaks": "Tweaks",
   "OSE.dialog.partysheet": "Party Overview",
+  "OSE.dialog.partysheetplaceholder": "Add Characters to the Party by dragging and dropping them into this window.",
   "OSE.dialog.partyselect": "Select PCs",
   "OSE.dialog.createItem": "Create Item",
   "OSE.dialog.itemType": "Item type",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -19,6 +19,7 @@
   "OSE.dialog.itemType": "Item type",
   "OSE.dialog.itemName": "Item name",
   "OSE.dialog.xp.deal": "Deal XP",
+  "OSE.dialog.xp.amount": "Amount",
   "OSE.dialog.xp.label": "XP",
   "OSE.dialog.generator": "Character generator",
   "OSE.dialog.generateSaves": "Generate Saves",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -13,6 +13,7 @@
 
   "OSE.dialog.tweaks": "Ajuster",
   "OSE.dialog.partysheet": "Fiche de Groupe",
+  "OSE.dialog.partysheetplaceholder": "Ajoutez des Personnages au Groupe en les faisant glisser dans cette fenêtre.",
   "OSE.dialog.partyselect": "Choisir PJs",
   "OSE.dialog.createItem": "Créer un Objet",
   "OSE.dialog.itemType": "Type de l'Objet",
@@ -218,7 +219,7 @@
   "OSE.items.typeTag": "Tapez une liste de tags descriptifs ex. 'Mêlée,Missile (5’–10’ / 11’–20’ / 21’–30’)' puis Entrée",
   "OSE.items.enterTag": "Tags",
   "OSE.items.pattern": "Marqueur de schéma d'attaque",
-  
+
   "OSE.items.Range": "Portée",
   "OSE.items.Melee": "Mêlée",
   "OSE.items.Missile": "Distance",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -19,6 +19,7 @@
   "OSE.dialog.itemType": "Type de l'Objet",
   "OSE.dialog.itemName": "Nom de l'Objet",
   "OSE.dialog.xp.deal": "Distribuer PX",
+  "OSE.dialog.xp.amount": "Quantité",
   "OSE.dialog.xp.label": "PX",
   "OSE.dialog.generator": "Générateur de personnage",
   "OSE.dialog.generateSaves": "Générer les Sauvegardes",

--- a/src/module/party/party.js
+++ b/src/module/party/party.js
@@ -1,8 +1,13 @@
 export class OseParty {
+  /**
+   * @public
+   * Returns all characters currently in the Party
+   * @return {OseActor[]}
+   */
   static get currentParty() {
     const v10 = isNewerVersion(game.version, "10.264");
-    const systemName = game.system.id == 'ose' ?game.system.id : 'ose-dev'
-    const characters = v10 ? 
+    const systemName = game.system.id == 'ose' ? game.system.id : 'ose-dev'
+    const characters = v10 ?
       game.actors.filter(
         (act) =>
           act.type === "character" &&
@@ -13,7 +18,7 @@ export class OseParty {
           act.data.type === "character" &&
           act.data.flags[systemName] &&
           act.data.flags[systemName].party === true);
-      console.log(characters)
+    console.log(characters)
     return characters;
   }
 }

--- a/src/scss/apps.scss
+++ b/src/scss/apps.scss
@@ -127,6 +127,21 @@
     width: 100%;
     flex-grow: 1;
   }
+
+  .drag-drop-placeholder {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    p {
+      text-align: center;
+      width: 90%;
+      color: $colorTan;
+    }
+  }
+
   .actor-list {
     margin: 0;
     overflow: auto;

--- a/src/templates/apps/party-sheet.html
+++ b/src/templates/apps/party-sheet.html
@@ -8,6 +8,13 @@
     {{/if}}
   </div>
   <div class="body party-members">
+    {{#if user.isGM}}
+    {{#if (eq partyActors.length 0)}}
+    <div class="drag-drop-placeholder">
+      <p>{{localize 'OSE.dialog.partysheetplaceholder'}}</p>
+    </div>
+    {{/if}}
+    {{/if}}
     <ol class="actor-list">
       {{#each partyActors as |e|}}
       <li class="actor flexrow" data-actor-id="{{e.id}}">

--- a/src/templates/apps/party-xp.html
+++ b/src/templates/apps/party-xp.html
@@ -1,6 +1,6 @@
 <form autocomplete="off">
   <div class="form-group">
-    <label>Amount</label>
+    <label>{{localize 'OSE.dialog.xp.amount'}}</label>
     <input name="total" placeholder="0" type="number" data-dtype="Number" />
   </div>
   <hr />
@@ -15,6 +15,6 @@
   </ul>
   <div class="dialog-buttons">
     <button type="button" data-action="deal-xp"><i class="fas
-          fa-hand-holding"></i> {{localize "OSE.dialog.xp.deal"}}</button>
+          fa-hand-holding"></i> {{localize 'OSE.dialog.xp.deal'}}</button>
   </div>
 </form>


### PR DESCRIPTION
I noticed that the question "How do I add characters to the party?" is asked a bit too much in the Discord, so I added a placeholder text that should have been there when I reworked this window >.>