### PR TITLE
fix: Monster abilities and weapons can expand to display their descriptions

### DIFF
--- a/src/templates/actors/partials/monster-attributes-tab.html
+++ b/src/templates/actors/partials/monster-attributes-tab.html
@@ -97,7 +97,7 @@
                 {{#each attackPatterns as |section pattern|}}
                 <ol class="attack-pattern">
                     {{#each section as |item|}}
-                    <li class="item-entry {{#if (or item.system.roll (eq item.type 'weapon'))}}item-rollable{{/if}}"
+                    <li class="item-entry item {{#if (or item.system.roll (eq item.type 'weapon'))}}item-rollable{{/if}}"
                         data-item-id="{{item.id}}">
                         <div class="item-header flexrow">
                             <div class="item-pattern pattern-{{pattern}}" title="{{localize 'OSE.items.pattern'}}">


### PR DESCRIPTION
This changeset adds the `item` class to attacks/abilities on the monster sheet's attributes tab.

Note: this could also be resolved by changing the selector at `actor-sheet.js:88` from `.item-entry.item` to `.item-entry`. I went with the most localized change.

Fixes #242 