### PR TITLE
fix: Read and delete treasure tables on Monster sheets

### DIFF
--- a/src/module/actor/monster-sheet.js
+++ b/src/module/actor/monster-sheet.js
@@ -155,8 +155,9 @@ export class OseActorSheetMonster extends OseActorSheet {
 
     // Settings
     data.config.morale = game.settings.get(game.system.id, "morale");
-    monsterData.details.treasure.link = TextEditor.enrichHTML(
-      monsterData.details.treasure.table
+    monsterData.details.treasure.link = await TextEditor.enrichHTML(
+      monsterData.details.treasure.table,
+      { async: true }
     );
     data.isNew = this.actor.isNew();
 
@@ -224,7 +225,7 @@ export class OseActorSheetMonster extends OseActorSheet {
         .index.filter((el) => el._id === data.id);
       link = `@Compendium[${data.pack}.${data.id}]{${tableData[0].name}}`;
     } else {
-      link = `@RollTable[${data.id}]`;
+      link = `@UUID[${data.uuid}]`;
     }
     const treasureTableKey = isNewerVersion(game.version, "10.264")
       ? "system.details.treasure.table"

--- a/src/module/actor/monster-sheet.js
+++ b/src/module/actor/monster-sheet.js
@@ -303,6 +303,13 @@ export class OseActorSheetMonster extends OseActorSheet {
       actorObject.rollAppearing({ event: ev, check: check });
     });
 
+    html.find(".treasure-table a").contextmenu((ev) => {
+      const treasureTableKey = isNewerVersion(game.version, "10.264")
+        ? "system.details.treasure.table"
+        : "data.details.treasure.table"; //v9-compatibility
+      this.actor.update({ [treasureTableKey]: null });
+    });
+
     // Everything below here is only needed if the sheet is editable
     if (!this.options.editable) return;
 


### PR DESCRIPTION
This changeset allows users to delete a monster's treasure rolltable by right clicking on it. It also allows monster treasure tables to successfully get added to the monster.

**Note**: I'd appreciate if someone familiar with maintaining v9 compatibility could have a look at this; I've been so buried in v10 work these days that I've lost track of what works in v9 vs. v10 :)

Fixes #226
Fixes #227