### PR TITLE
fix: Render item descriptions

### DIFF
--- a/src/module/actor/monster-sheet.js
+++ b/src/module/actor/monster-sheet.js
@@ -52,7 +52,7 @@ export class OseActorSheetMonster extends OseActorSheet {
     }    
 
     // Partition items by category
-    let [weapons, items, armors, spells, containers] = itemsData.reduce(
+    let [weapons, items, armors, spells, containers, treasures] = itemsData.reduce(
       (arr, item) => {
         const itemData = item?.system || item?.data?.data; //v9-compatibility
         // Classify items into types
@@ -74,7 +74,9 @@ export class OseActorSheetMonster extends OseActorSheet {
             arr[0].push(item);
             break;
           case "item":
-            arr[1].push(item);
+            arr[
+              (item.system || item.data.data).treasure ? 5 : 1
+            ].push(item);
             break;
           case "armor":
             arr[2].push(item);
@@ -89,7 +91,7 @@ export class OseActorSheetMonster extends OseActorSheet {
 
         return arr;
       },
-      [[], [], [], [], []]
+      [[], [], [], [], [], []]
     );
 
     // Sort spells by level
@@ -119,12 +121,7 @@ export class OseActorSheetMonster extends OseActorSheet {
       return arr;
     });
     // Assign and return
-    data.owned = {
-      weapons: weapons,
-      items: items,
-      containers: containers,
-      armors: armors,
-    };
+    data.owned = { weapons, items, containers, armors, treasures };
     
     data.attackPatterns = attackPatterns;
     // Sort items and spells alphabetically within their groups

--- a/src/module/item/entity.js
+++ b/src/module/item/entity.js
@@ -36,7 +36,7 @@ export class OseItem extends Item {
     // Rich text description
     if (isNewerVersion(game.version, "10.264")) {
       itemData.enrichedDescription = await TextEditor.enrichHTML(
-        itemData.description,
+        itemData.details?.description || itemData.description,
         { async: true }
       );
     } else {

--- a/src/templates/items/ability-sheet.html
+++ b/src/templates/items/ability-sheet.html
@@ -62,8 +62,13 @@
         </div>
       </div>
       <div class="description">
-        {{editor enrichedDescription target="system.description" button=true
-        owner=owner editable=editable async=true}}
+        {{editor system.enrichedDescription
+          target="system.description"
+          button=true
+          owner=owner
+          editable=editable
+          async=true
+        }}
       </div>
     </div>
   </section>

--- a/src/templates/items/armor-sheet.html
+++ b/src/templates/items/armor-sheet.html
@@ -64,7 +64,7 @@
         </div>
       </div>
       <div class="description">
-        {{editor enrichedDescription target="system.description" button=true
+        {{editor system.enrichedDescription target="system.description" button=true
         owner=owner editable=editable async=true}}
       </div>
     </div>

--- a/src/templates/items/container-sheet.html
+++ b/src/templates/items/container-sheet.html
@@ -1,4 +1,4 @@
-{{#if {isV10}}}
+{{#if (isV10)}}
 <form class="{{cssClass}}" autocomplete="off">
   <header class="sheet-header">
     <img class="profile-img" src="{{img}}" data-edit="img" title="{{name}}" />
@@ -25,8 +25,13 @@
         </div>
       </div>
       <div class="description weapon-editor">
-        {{editor enrichedDescription target="system.description" button=true
-        owner=owner editable=editable async=true}}
+        {{editor system.enrichedDescription
+          target="system.description"
+          button=true
+          owner=owner
+          editable=editable
+          async=true
+        }}
       </div>
     </div>
   </section>

--- a/src/templates/items/item-sheet.html
+++ b/src/templates/items/item-sheet.html
@@ -82,9 +82,13 @@
         </div>
       </div>
       <div class="description weapon-editor">
-        {{editor enrichedDescription
-        target="system.details.description" button=true editable=editable
-        async=true}}
+        {{editor system.enrichedDescription
+          target="system.details.description"
+          button=true
+          owner=owner
+          editable=editable
+          async=true
+        }}
       </div>
     </div>
   </section>

--- a/src/templates/items/spell-sheet.html
+++ b/src/templates/items/spell-sheet.html
@@ -56,8 +56,13 @@
         </div>
       </div>
       <div class="description">
-        {{editor enrichedDescription target="system.description" button=true
-        owner=owner editable=editable async=true}}
+        {{editor system.enrichedDescription
+          target="system.description"
+          button=true
+          owner=owner
+          editable=editable
+          async=true
+        }}
       </div>
     </div>
   </section>

--- a/src/templates/items/weapon-sheet.html
+++ b/src/templates/items/weapon-sheet.html
@@ -90,13 +90,18 @@
         <div class="form-group">
           <label>{{localize 'OSE.items.Slow'}}</label>
           <div class="form-fields">
-            <input type="checkbox" name="system.slow" value="{{system.slow}}" {{checked system.slow}} data-dtype="Number" />
+            <input type="checkbox" name="system.slow" {{checked system.slow}} data-dtype="Boolean" />
           </div>
         </div>
       </div>
       <div class="description weapon-editor">
-        {{editor enrichedDescription target="system.description" button=true
-        owner=owner editable=editable async=true}}
+        {{editor system.enrichedDescription
+          target="system.description"
+          button=true
+          owner=owner
+          editable=editable
+          async=true
+        }}
       </div>
     </div>
   </section>


### PR DESCRIPTION
### Intent
This changeset does a few things:
1. Container sheets will now render
2. Sheets for all item types will now display their descriptive text
3. Monster inventories now have treasure in the right grid
4. The weapon sheet's `slow` checkbox should be less wonky on first interaction

### Screenshots
#### Item Descriptions
![image](https://user-images.githubusercontent.com/1731267/194690240-947dfc67-8c23-4e16-9338-ea95cfe4d90f.png)
#### Monster Treasure
![image](https://user-images.githubusercontent.com/1731267/194690271-a0f8b573-9150-4c5d-afa8-f2988e83d706.png)

Fixes #231 