### PR TITLE
Chore: rip out v9 compatibility and other chore commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,18 +18,18 @@ jobs:
           node-version: "16"
 
       # # Caching to improve build speed
-      # - name: Enable caching for Node.js modules
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: .npm
-      #     key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-      #     restore-keys: |
-      #       ${{ runner.OS }}-node-
-      #       ${{ runner.OS }}-
+      - name: Enable caching for Node.js modules
+        uses: actions/cache@v2
+        with:
+          path: .npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+            ${{ runner.OS }}-
 
       # Get dev dependencies for the package, including Gulp and Rollup
       - name: Install dev dependencies
-        run: npm ci #--cache .npm --prefer-offline
+        run: npm ci --cache .npm --prefer-offline --ignore-scripts
 
       # Create a build using Gulp build script
       - name: Run Gulp build script

--- a/src/e2e/actor/character.e2e.test.js
+++ b/src/e2e/actor/character.e2e.test.js
@@ -7,7 +7,6 @@ export const options = {
 
 export default ({before, beforeEach, after, describe, it, expect, ...context}) => {
   const testCharacterName = 'Quench Test Character';
-  const inputDelay = 100;
   const prepareActor = async (data) => {
     await trashChat();
     await trashActor();

--- a/src/e2e/testUtils.js
+++ b/src/e2e/testUtils.js
@@ -1,4 +1,4 @@
-const inputDelay = 100;
+const inputDelay = 120;
 
 const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms)); 
 

--- a/src/module/actor/actor-sheet.js
+++ b/src/module/actor/actor-sheet.js
@@ -299,8 +299,7 @@ export class OseActorSheet extends ActorSheet {
     const itemObj = this.object.items.get(item.id);
     const alreadyExists = container.system.itemIds.find((i) => i.id == item.id);
     if (!alreadyExists) {
-      const newList = [...container.system.itemIds];
-      newList.push(item.id);
+      const newList = [...container.system.itemIds, item.id];
       await container.update({ system: { itemIds: newList } });
       await itemObj.update({ system: { containerId: container.id } });
     }

--- a/src/module/actor/actor-sheet.js
+++ b/src/module/actor/actor-sheet.js
@@ -108,7 +108,7 @@ export class OseActorSheet extends ActorSheet {
     if (item.type === "container" && itemData.itemIds) {
       const containedItems = itemData.itemIds;
       const updateData = containedItems.reduce((acc, val) => {
-        acc.push({ _id: val.id, "data.containerId": "" });
+        acc.push({ _id: val.id, "system.containerId": "" });
         return acc;
       }, []);
 
@@ -125,9 +125,9 @@ export class OseActorSheet extends ActorSheet {
     const itemData = item?.system;
 
     if (decrement) {
-      item.update({ "data.quantity.value": itemData.quantity.value - 1 });
+      item.update({ "system.quantity.value": itemData.quantity.value - 1 });
     } else {
-      item.update({ "data.quantity.value": itemData.quantity.value + 1 });
+      item.update({ "system.quantity.value": itemData.quantity.value + 1 });
     }
   }
 
@@ -135,10 +135,10 @@ export class OseActorSheet extends ActorSheet {
     event.preventDefault();
     const item = this._getItemFromActor(event);
     if (event.target.dataset.field == "cast") {
-      return item.update({ "data.cast": parseInt(event.target.value) });
+      return item.update({ "system.cast": parseInt(event.target.value) });
     } else if (event.target.dataset.field == "memorize") {
       return item.update({
-        "data.memorized": parseInt(event.target.value),
+        "system.memorized": parseInt(event.target.value),
       });
     }
   }
@@ -153,7 +153,7 @@ export class OseActorSheet extends ActorSheet {
       const itemData = item?.system;
       item.update({
         _id: item.id,
-        "data.cast": itemData.memorized,
+        "system.cast": itemData.memorized,
       });
     });
   }
@@ -212,13 +212,13 @@ export class OseActorSheet extends ActorSheet {
       targetData.containerId === ""
     ) {
       this.actor.updateEmbeddedDocuments("Item", [
-        { _id: source.id, "data.containerId": target.id },
+        { _id: source.id, "system.containerId": target.id },
       ]);
       return;
     }
-    if (source?.data.containerId !== "") {
+    if (source?.system.containerId !== "") {
       this.actor.updateEmbeddedDocuments("Item", [
-        { _id: source.id, "data.containerId": "" },
+        { _id: source.id, "system.containerId": "" },
       ]);
     }
 
@@ -407,11 +407,11 @@ export class OseActorSheet extends ActorSheet {
 
     if (event.target.dataset.field === "value") {
       return item.update({
-        "data.quantity.value": parseInt(event.target.value),
+        "system.quantity.value": parseInt(event.target.value),
       });
     } else if (event.target.dataset.field === "max") {
       return item.update({
-        "data.quantity.max": parseInt(event.target.value),
+        "system.quantity.max": parseInt(event.target.value),
       });
     }
   }

--- a/src/module/actor/actor-sheet.js
+++ b/src/module/actor/actor-sheet.js
@@ -184,10 +184,7 @@ export class OseActorSheet extends ActorSheet {
     let actorObject = this.actor;
     let element = event.currentTarget;
     let attack = element.parentElement.parentElement.dataset.attack;
-    const rollData = {
-      roll: {},
-    };
-    actorObject.targetAttack(rollData, attack, {
+    actorObject.targetAttack({roll:{}}, attack, {
       type: attack,
       skipDialog: event.ctrlKey || event.metaKey,
     });

--- a/src/module/actor/actor-sheet.js
+++ b/src/module/actor/actor-sheet.js
@@ -122,13 +122,11 @@ export class OseActorSheet extends ActorSheet {
    */
   _useConsumable(event, decrement) {
     const item = this._getItemFromActor(event);
-    const itemData = item?.system;
-
-    if (decrement) {
-      item.update({ "system.quantity.value": itemData.quantity.value - 1 });
-    } else {
-      item.update({ "system.quantity.value": itemData.quantity.value + 1 });
-    }
+    if (!item) return null;
+    let {
+      quantity: { value: quantity },
+    } = item.system;
+    item.update({ "system.quantity.value": decrement ? --quantity : ++quantity });
   }
 
   async _onSpellChange(event) {
@@ -187,7 +185,6 @@ export class OseActorSheet extends ActorSheet {
     let element = event.currentTarget;
     let attack = element.parentElement.parentElement.dataset.attack;
     const rollData = {
-      actor: this,
       roll: {},
     };
     actorObject.targetAttack(rollData, attack, {

--- a/src/module/actor/actor-sheet.js
+++ b/src/module/actor/actor-sheet.js
@@ -200,6 +200,7 @@ export class OseActorSheet extends ActorSheet {
     const dropTarget = event.target.closest("[data-item-id]");
     const targetId = dropTarget ? dropTarget.dataset.itemId : null;
     const target = siblings.find((s) => s.data._id === targetId);
+    if (!target) throw new Error("Couldn't drop near "+ event.target);
     const targetData = target?.system;
 
     // Dragging items into a container

--- a/src/module/actor/actor-sheet.js
+++ b/src/module/actor/actor-sheet.js
@@ -277,7 +277,6 @@ export class OseActorSheet extends ActorSheet {
     const targetItem = this.object.items.get(targetEl?.dataset?.itemId);
     let targetIsContainer = targetItem?.type == "container" ? true : false;
     const exists = this.object.items.get(item.id) ? true : false;
-    console.log(exists);
 
     if (targetIsContainer) {
       return this._onContainerItemAdd(item, targetItem);

--- a/src/module/actor/actor-sheet.js
+++ b/src/module/actor/actor-sheet.js
@@ -126,7 +126,9 @@ export class OseActorSheet extends ActorSheet {
     let {
       quantity: { value: quantity },
     } = item.system;
-    item.update({ "system.quantity.value": decrement ? --quantity : ++quantity });
+    item.update({
+      "system.quantity.value": decrement ? --quantity : ++quantity,
+    });
   }
 
   async _onSpellChange(event) {
@@ -184,7 +186,7 @@ export class OseActorSheet extends ActorSheet {
     let actorObject = this.actor;
     let element = event.currentTarget;
     let attack = element.parentElement.parentElement.dataset.attack;
-    actorObject.targetAttack({roll:{}}, attack, {
+    actorObject.targetAttack({ roll: {} }, attack, {
       type: attack,
       skipDialog: event.ctrlKey || event.metaKey,
     });
@@ -323,13 +325,12 @@ export class OseActorSheet extends ActorSheet {
     if (!container) {
       return this.actor.createEmbeddedDocuments("Item", itemData);
     }
-    if (container) {
-      let itemIds = container.system.itemIds;
-      itemIds.push(itemData.id);
-      const item = this.actor.items.get(itemData[0]._id);
-      await item.update({ system: { containerId: container.id } });
-      await container.update({ system: { itemIds: itemIds } });
-    }
+
+    let itemIds = container.system.itemIds;
+    itemIds.push(itemData.id);
+    const item = this.actor.items.get(itemData[0]._id);
+    await item.update({ system: { containerId: container.id } });
+    await container.update({ system: { itemIds: itemIds } });
   }
 
   /* -------------------------------------------- */
@@ -507,8 +508,8 @@ export class OseActorSheet extends ActorSheet {
     html.find(".inventory .item-category-title").click((event) => {
       this._toggleItemCategory(event);
     });
-    html.find(".inventory .item-category-title input").click((evt) => {
-      evt.stopPropagation();
+    html.find(".inventory .item-category-title input").click((event) => {
+      event.stopPropagation();
     });
     html.find(".inventory .category-caret").click((event) => {
       this._toggleContainedItems(event);

--- a/src/module/actor/actor-sheet.js
+++ b/src/module/actor/actor-sheet.js
@@ -286,7 +286,7 @@ export class OseActorSheet extends ActorSheet {
     }
   }
   async _onContainerItemRemove(item, container) {
-    let newList = container.system.itemIds.filter((i) => i.id != item.id);
+    const newList = container.system.itemIds.filter((s) => s != item.id);
     const itemObj = this.object.items.get(item.id);
     await container.update({ system: { itemIds: newList } });
     await itemObj.update({ system: { containerId: "" } });

--- a/src/module/actor/character-sheet.js
+++ b/src/module/actor/character-sheet.js
@@ -93,10 +93,10 @@ export class OseActorSheetCharacter extends OseActorSheet {
     let choices = CONFIG.OSE.languages;
 
     let templateData = { choices: choices },
-        dlg = await renderTemplate(
-          `${OSE.systemPath()}/templates/actors/dialogs/lang-create.html`,
-          templateData
-        );
+      dlg = await renderTemplate(
+        `${OSE.systemPath()}/templates/actors/dialogs/lang-create.html`,
+        templateData
+      );
     //Create Dialog window
     return new Promise((resolve) => {
       new Dialog({
@@ -123,7 +123,7 @@ export class OseActorSheetCharacter extends OseActorSheet {
   }
 
   _pushLang(table) {
-    const data = this.actor.data.data;
+    const data = this.actor.system;
     let update = data[table]; //V10 compatibility
     this._chooseLang().then((dialogInput) => {
       const name = CONFIG.OSE.languages[dialogInput.choice];
@@ -140,7 +140,7 @@ export class OseActorSheetCharacter extends OseActorSheet {
   }
 
   _popLang(table, lang) {
-    const data = this.actor.data.data;
+    const data = this.actor.system;
     let update = data[table].value.filter((el) => el != lang);
     let newData = {};
     newData[table] = { value: update };

--- a/src/module/actor/character-sheet.js
+++ b/src/module/actor/character-sheet.js
@@ -92,7 +92,7 @@ export class OseActorSheetCharacter extends OseActorSheet {
   async _chooseLang() {
     let choices = CONFIG.OSE.languages;
 
-    let templateData = { choices: choices },
+    let templateData = { choices },
       dlg = await renderTemplate(
         `${OSE.systemPath()}/templates/actors/dialogs/lang-create.html`,
         templateData

--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -122,8 +122,8 @@ export class OseActor extends Actor {
       thac0 = CONFIG.OSE.monster_thac0[k];
     });
     this.update({
-      "data.thac0.value": thac0,
-      "data.saves": {
+      "system.thac0.value": thac0,
+      "system.saves": {
         death: {
           value: saves.d,
         },

--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -9,9 +9,9 @@ export class OseActor extends Actor {
   prepareData() {
     super.prepareData();
     if (this.type !== "character") {
-      const data = this?.system;
+      const data = this.system;
 
-      const actorType = this?.type;
+      const actorType = this.type;
 
       // Compute modifiers from actor scores
       this._isSlow();
@@ -65,8 +65,8 @@ export class OseActor extends Actor {
   /*  Socket Listeners and Handlers
     /* -------------------------------------------- */
   getExperience(value, options = {}) {
-    const actorData = this?.system;
-    const actorType = this?.type;
+    const actorData = this.system;
+    const actorType = this.type;
     // @TODO this seems like not the best spot for defining the xpKey const
     const xpKey = "system.details.xp.value";
 
@@ -77,7 +77,7 @@ export class OseActor extends Actor {
       value + (actorData.details.xp.bonus * value) / 100
     );
     return this.update({
-      "system.details.xp.value": modified + actorData.details.xp.value,
+      [xpKey]: modified + actorData.details.xp.value,
     }).then(() => {
       const speaker = ChatMessage.getSpeaker({ actor: this });
       ChatMessage.create({
@@ -91,9 +91,9 @@ export class OseActor extends Actor {
   }
 
   isNew() {
-    const data = this?.system;
+    const data = this.system;
 
-    const actorType = this?.type;
+    const actorType = this.type;
     if (actorType == "character") {
       return this.system.isNew;
     } else if (actorType == "monster") {
@@ -148,7 +148,7 @@ export class OseActor extends Actor {
   /* -------------------------------------------- */
 
   rollHP(options = {}) {
-    const actorData = this?.system;
+    const actorData = this.system;
     let roll = new Roll(actorData.hp.hd).roll({ async: false });
     return this.update({
       data: {
@@ -163,8 +163,8 @@ export class OseActor extends Actor {
   rollSave(save, options = {}) {
     const label = game.i18n.localize(`OSE.saves.${save}.long`);
     const rollParts = ["1d20"];
-    const actorData = this?.system;
-    const actorType = this?.type;
+    const actorData = this.system;
+    const actorType = this.type;
 
     const data = {
       actor: this,
@@ -195,7 +195,7 @@ export class OseActor extends Actor {
   }
 
   rollMorale(options = {}) {
-    const actorData = this?.system;
+    const actorData = this.system;
 
     const rollParts = ["2d6"];
 
@@ -223,7 +223,7 @@ export class OseActor extends Actor {
     const label = game.i18n.localize(`OSE.roll.loyalty`);
     const rollParts = ["2d6"];
 
-    const actorData = this?.system;
+    const actorData = this.system;
 
     const data = {
       actor: this,
@@ -288,11 +288,11 @@ export class OseActor extends Actor {
   }
 
   rollCheck(score, options = {}) {
-    const actorType = this?.type;
+    const actorType = this.type;
 
     if (actorType !== "character") return;
 
-    const actorData = this?.system;
+    const actorData = this.system;
 
     const label = game.i18n.localize(`OSE.scores.${score}.long`);
     const rollParts = ["1d20"];
@@ -325,9 +325,9 @@ export class OseActor extends Actor {
   }
 
   rollHitDice(options = {}) {
-    const actorType = this?.type;
+    const actorType = this.type;
 
-    const actorData = this?.system;
+    const actorData = this.system;
 
     const label = game.i18n.localize(`OSE.roll.hd`);
     const rollParts = [actorData.hp.hd];
@@ -355,10 +355,10 @@ export class OseActor extends Actor {
   }
 
   rollAppearing(options = {}) {
-    const actorType = this?.type;
+    const actorType = this.type;
     if (actorType !== "monster") return;
 
-    const actorData = this?.system;
+    const actorData = this.system;
 
     const rollParts = [];
     let label = "";
@@ -391,9 +391,9 @@ export class OseActor extends Actor {
   }
 
   rollExploration(expl, options = {}) {
-    const actorType = this?.type;
+    const actorType = this.type;
     if (actorType !== "character") return;
-    const actorData = this?.system;
+    const actorData = this.system;
 
     const label = game.i18n.localize(`OSE.exploration.${expl}.long`);
     const rollParts = ["1d6"];
@@ -427,7 +427,7 @@ export class OseActor extends Actor {
   }
 
   rollDamage(attData, options = {}) {
-    const data = this?.system;
+    const data = this.system;
 
     const rollData = {
       actor: this,
@@ -476,7 +476,7 @@ export class OseActor extends Actor {
   }
 
   rollAttack(attData, options = {}) {
-    const data = this?.system;
+    const data = this.system;
 
     const rollParts = ["1d20"];
     const dmgParts = [];
@@ -556,9 +556,9 @@ export class OseActor extends Actor {
   }
 
   _isSlow() {
-    const actorData = this?.system;
+    const actorData = this.system;
 
-    const actorItems = this?.items;
+    const actorItems = this.items;
 
     actorData.isSlow = ![...actorItems.values()].every((item) => {
       const itemData = item?.system;
@@ -572,9 +572,9 @@ export class OseActor extends Actor {
   _calculateMovement() {
     if (actor.type === "character") return;
 
-    const actorData = this?.system;
+    const actorData = this.system;
 
-    const actorItems = this?.items;
+    const actorItems = this.items;
 
     const option = game.settings.get(game.system.id, "encumbranceOption");
     const weight = actorData.encumbrance.value;

--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -8,10 +8,10 @@ export class OseActor extends Actor {
 
   prepareData() {
     super.prepareData();
-    if (this.type !== 'character') {
-      const data = this?.system || this?.data?.data; //v9-compatibility
+    if (this.type !== "character") {
+      const data = this?.system;
 
-      const actorType = this?.type || this?.data?.type; //v9-compatibility
+      const actorType = this?.type;
 
       // Compute modifiers from actor scores
       this._isSlow();
@@ -31,14 +31,10 @@ export class OseActor extends Actor {
 
   prepareDerivedData() {
     // @TODO Once the monster data model is done, this can go
-    if (this.type === 'character')
-      this.system.prepareDerivedData?.();
+    if (this.type === "character") this.system.prepareDerivedData?.();
   }
 
   static async update(data, options = {}) {
-    //v9-compatibility
-    data = isNewerVersion(game.version, "10.264") ? data : data.data;
-
     // Compute AAC from AC
     if (data?.ac?.value) {
       data.aac = { value: 19 - data.ac.value };
@@ -69,11 +65,10 @@ export class OseActor extends Actor {
   /*  Socket Listeners and Handlers
     /* -------------------------------------------- */
   getExperience(value, options = {}) {
-    const actorData = this?.system || this?.data?.data; //v9-compatibility
-    const actorType = this?.type || this?.data?.type; //v9-compatibility
-    const xpKey = isNewerVersion(game.version, "10.264")
-      ? "system.details.xp.value"
-      : "data.details.xp.value"; //v9-compatibility
+    const actorData = this?.system;
+    const actorType = this?.type;
+    // @TODO this seems like not the best spot for defining the xpKey const
+    const xpKey = "system.details.xp.value";
 
     if (actorType !== "character") {
       return;
@@ -96,9 +91,9 @@ export class OseActor extends Actor {
   }
 
   isNew() {
-    const data = this?.system || this?.data?.data; //v9-compatibility
+    const data = this?.system;
 
-    const actorType = this?.type || this?.data?.type; //v9-compatibility
+    const actorType = this?.type;
     if (actorType == "character") {
       return this.system.isNew;
     } else if (actorType == "monster") {
@@ -153,7 +148,7 @@ export class OseActor extends Actor {
   /* -------------------------------------------- */
 
   rollHP(options = {}) {
-    const actorData = this?.system || this?.data?.data; //v9-compatibility
+    const actorData = this?.system;
     let roll = new Roll(actorData.hp.hd).roll({ async: false });
     return this.update({
       data: {
@@ -168,11 +163,11 @@ export class OseActor extends Actor {
   rollSave(save, options = {}) {
     const label = game.i18n.localize(`OSE.saves.${save}.long`);
     const rollParts = ["1d20"];
-    const actorData = this?.system || this?.data?.data; //v9-compatibility
-    const actorType = this?.type || this?.data?.type; //v9-compatibility
+    const actorData = this?.system;
+    const actorType = this?.type;
 
     const data = {
-      actor: isNewerVersion(game.version, "10.264") ? this : this.data, //v9-compatibility
+      actor: this,
       roll: {
         type: "above",
         target: actorData.saves[save].value,
@@ -200,12 +195,12 @@ export class OseActor extends Actor {
   }
 
   rollMorale(options = {}) {
-    const actorData = this?.system || this?.data?.data; //v9-compatibility
+    const actorData = this?.system;
 
     const rollParts = ["2d6"];
 
     const data = {
-      actor: isNewerVersion(game.version, "10.264") ? this : this.data, //v9-compatibility
+      actor: this,
       roll: {
         type: "below",
         target: actorData.details.morale,
@@ -228,10 +223,10 @@ export class OseActor extends Actor {
     const label = game.i18n.localize(`OSE.roll.loyalty`);
     const rollParts = ["2d6"];
 
-    const actorData = this?.system || this?.data?.data; //v9-compatibility
+    const actorData = this?.system;
 
     const data = {
-      actor: isNewerVersion(game.version, "10.264") ? this : this.data, //v9-compatibility
+      actor: this,
       roll: {
         type: "below",
         target: actorData.retainer.loyalty,
@@ -254,24 +249,24 @@ export class OseActor extends Actor {
     const rollParts = ["2d6"];
 
     const data = {
-      actor: isNewerVersion(game.version, "10.264") ? this : this.data, //v9-compatibility
+      actor: this,
       roll: {
         type: "table",
         table: {
           2: game.i18n.format("OSE.reaction.Hostile", {
-            name: this.data.name,
+            name: this.name,
           }),
           3: game.i18n.format("OSE.reaction.Unfriendly", {
-            name: this.data.name,
+            name: this.name,
           }),
           6: game.i18n.format("OSE.reaction.Neutral", {
-            name: this.data.name,
+            name: this.name,
           }),
           9: game.i18n.format("OSE.reaction.Indifferent", {
-            name: this.data.name,
+            name: this.name,
           }),
           12: game.i18n.format("OSE.reaction.Friendly", {
-            name: this.data.name,
+            name: this.name,
           }),
         },
       },
@@ -293,17 +288,17 @@ export class OseActor extends Actor {
   }
 
   rollCheck(score, options = {}) {
-    const actorType = this?.type || this?.data?.type; //v9-compatibility
+    const actorType = this?.type;
 
     if (actorType !== "character") return;
 
-    const actorData = this?.system || this?.data?.data; //v9-compatibility
+    const actorData = this?.system;
 
     const label = game.i18n.localize(`OSE.scores.${score}.long`);
     const rollParts = ["1d20"];
 
     const data = {
-      actor: isNewerVersion(game.version, "10.264") ? this : this.data, //v9-compatibility
+      actor: this,
       roll: {
         type: "check",
         target: actorData.scores[score].value,
@@ -330,9 +325,9 @@ export class OseActor extends Actor {
   }
 
   rollHitDice(options = {}) {
-    const actorType = this?.type || this?.data?.type; //v9-compatibility
+    const actorType = this?.type;
 
-    const actorData = this?.system || this?.data?.data; //v9-compatibility
+    const actorData = this?.system;
 
     const label = game.i18n.localize(`OSE.roll.hd`);
     const rollParts = [actorData.hp.hd];
@@ -341,7 +336,7 @@ export class OseActor extends Actor {
     }
 
     const data = {
-      actor: isNewerVersion(game.version, "10.264") ? this : this.data, //v9-compatibility
+      actor: this,
       roll: {
         type: "hitdice",
       },
@@ -360,10 +355,10 @@ export class OseActor extends Actor {
   }
 
   rollAppearing(options = {}) {
-    const actorType = this?.type || this?.data?.type; //v9-compatibility
+    const actorType = this?.type;
     if (actorType !== "monster") return;
 
-    const actorData = this?.system || this?.data?.data; //v9-compatibility
+    const actorData = this?.system;
 
     const rollParts = [];
     let label = "";
@@ -375,7 +370,7 @@ export class OseActor extends Actor {
       label = "(1)";
     }
     const data = {
-      actor: isNewerVersion(game.version, "10.264") ? this : this.data, //v9-compatibility
+      actor: this,
       roll: {
         type: {
           type: "appearing",
@@ -396,15 +391,15 @@ export class OseActor extends Actor {
   }
 
   rollExploration(expl, options = {}) {
-    const actorType = this?.type || this?.data?.type; //v9-compatibility
+    const actorType = this?.type;
     if (actorType !== "character") return;
-    const actorData = this?.system || this?.data?.data; //v9-compatibility
+    const actorData = this?.system;
 
     const label = game.i18n.localize(`OSE.exploration.${expl}.long`);
     const rollParts = ["1d6"];
 
     const data = {
-      actor: isNewerVersion(game.version, "10.264") ? this : this.data, //v9-compatibility
+      actor: this,
       roll: {
         type: "below",
         target: actorData.exploration[expl],
@@ -416,7 +411,8 @@ export class OseActor extends Actor {
     };
 
     let skip =
-      options.fastForward || (options.event && (options.event.ctrlKey || options.event.metaKey));
+      options.fastForward ||
+      (options.event && (options.event.ctrlKey || options.event.metaKey));
 
     // Roll and return
     return OseDice.Roll({
@@ -431,10 +427,10 @@ export class OseActor extends Actor {
   }
 
   rollDamage(attData, options = {}) {
-    const data = this?.system || this?.data?.data; //v9-compatibility
+    const data = this?.system;
 
     const rollData = {
-      actor: isNewerVersion(game.version, "10.264") ? this : this.data, //v9-compatibility
+      actor: this,
       item: attData.item,
       roll: {
         type: "damage",
@@ -480,12 +476,12 @@ export class OseActor extends Actor {
   }
 
   rollAttack(attData, options = {}) {
-    const data = this?.system || this?.data?.data; //v9-compatibility
+    const data = this?.system;
 
     const rollParts = ["1d20"];
     const dmgParts = [];
     let label = game.i18n.format("OSE.roll.attacks", {
-      name: this.data.name,
+      name: this.name,
     });
     if (!attData.item) {
       dmgParts.push("1d6");
@@ -519,7 +515,7 @@ export class OseActor extends Actor {
       dmgParts.push(data.scores.str.mod);
     }
     const rollData = {
-      actor: isNewerVersion(game.version, "10.264") ? this : this.data, //v9-compatibility
+      actor: this,
       item: attData.item,
       itemId: attData.item?._id,
       roll: {
@@ -551,21 +547,21 @@ export class OseActor extends Actor {
   async applyDamage(amount = 0, multiplier = 1) {
     amount = Math.floor(parseInt(amount) * multiplier);
 
-    const {value, max} = this.system.hp;
+    const { value, max } = this.system.hp;
 
     // Update the Actor
     return this.update({
-      "system.hp.value": Math.clamped(value - amount, 0, max)
+      "system.hp.value": Math.clamped(value - amount, 0, max),
     });
   }
 
   _isSlow() {
-    const actorData = this?.system || this?.data?.data; //v9-compatibility
+    const actorData = this?.system;
 
-    const actorItems = this?.items || this?.data?.items; //v9-compatibility
+    const actorItems = this?.items;
 
     actorData.isSlow = ![...actorItems.values()].every((item) => {
-      const itemData = item?.system || item?.data?.data; // v9-compatibility
+      const itemData = item?.system;
       if (item.type !== "weapon" || !itemData.slow || !itemData.equipped) {
         return true;
       }
@@ -574,11 +570,11 @@ export class OseActor extends Actor {
   }
 
   _calculateMovement() {
-    if (actor.type === 'character') return;
-    
-    const actorData = this?.system || this?.data?.data; //v9-compatibility
+    if (actor.type === "character") return;
 
-    const actorItems = this?.items || this?.data?.items; //v9-compatibility
+    const actorData = this?.system;
+
+    const actorItems = this?.items;
 
     const option = game.settings.get(game.system.id, "encumbranceOption");
     const weight = actorData.encumbrance.value;
@@ -599,7 +595,7 @@ export class OseActor extends Actor {
       const armors = actorItems.filter((i) => i.type === "armor");
       let heaviest = 0;
       armors.forEach((a) => {
-        const armorData = a?.system || a?.data?.data; //v9-compatibility
+        const armorData = a?.system;
         const weight = armorData.type;
         const equipped = armorData.equipped;
         if (equipped) {

--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -77,7 +77,7 @@ export class OseActor extends Actor {
       value + (actorData.details.xp.bonus * value) / 100
     );
     return this.update({
-      [xpKey]: modified + actorData.details.xp.value,
+      "system.details.xp.value": modified + actorData.details.xp.value,
     }).then(() => {
       const speaker = ChatMessage.getSpeaker({ actor: this });
       ChatMessage.create({

--- a/src/module/actor/monster-sheet.js
+++ b/src/module/actor/monster-sheet.js
@@ -37,83 +37,79 @@ export class OseActorSheetMonster extends OseActorSheet {
    * @private
    */
   _prepareItems(data) {
-    const itemsData = this.actor?.items || this.actor?.data?.items; //v9-compatibility
+    const itemsData = this.actor?.items;
     const containerContents = {};
-    const attackPatterns = {
-    };
+    const attackPatterns = {};
 
     let colors = Object.keys(CONFIG.OSE.colors);
     colors.push("transparent");
 
     // Set up attack patterns in specific order
-    for (var i = 0; i < colors.length; i++)
-    {
+    for (var i = 0; i < colors.length; i++) {
       attackPatterns[colors[i]] = [];
-    }    
+    }
 
     // Partition items by category
-    let [weapons, items, armors, spells, containers, treasures] = itemsData.reduce(
-      (arr, item) => {
-        const itemData = item?.system || item?.data?.data; //v9-compatibility
-        // Classify items into types
-        const containerId = itemData.containerId;
-        if (containerId) {
-          containerContents[containerId] = [
-            ...(containerContents[containerId] || []),
-            item,
-          ];
-          return arr;
-        }
-        // Add Items to their respective attack groups
-        if (["weapon", "ability"].includes(item.type)) {
-          attackPatterns[item.data.data.pattern].push(item);
-        }
-        // Classify items into types
-        switch (item.type) {
-          case "weapon":
-            arr[0].push(item);
-            break;
-          case "item":
-            arr[
-              (item.system || item.data.data).treasure ? 5 : 1
-            ].push(item);
-            break;
-          case "armor":
-            arr[2].push(item);
-            break;
-          case "spell":
-            arr[3].push(item);
-            break;
-          case "container":
-            arr[4].push(item);
-            break;
-        }
+    let [weapons, items, armors, spells, containers, treasures] =
+      itemsData.reduce(
+        (arr, item) => {
+          const itemData = item?.system;
+          // Classify items into types
+          const containerId = itemData.containerId;
+          if (containerId) {
+            containerContents[containerId] = [
+              ...(containerContents[containerId] || []),
+              item,
+            ];
+            return arr;
+          }
+          // Add Items to their respective attack groups
+          if (["weapon", "ability"].includes(item.type)) {
+            attackPatterns[item.system.pattern].push(item);
+          }
+          // Classify items into types
+          switch (item.type) {
+            case "weapon":
+              arr[0].push(item);
+              break;
+            case "item":
+              arr[item.system.treasure ? 5 : 1].push(item);
+              break;
+            case "armor":
+              arr[2].push(item);
+              break;
+            case "spell":
+              arr[3].push(item);
+              break;
+            case "container":
+              arr[4].push(item);
+              break;
+          }
 
-        return arr;
-      },
-      [[], [], [], [], [], []]
-    );
+          return arr;
+        },
+        [[], [], [], [], [], []]
+      );
 
     // Sort spells by level
     var sortedSpells = {};
     var slots = {};
     for (var i = 0; i < spells.length; i++) {
-      let lvl = spells[i].data.data.lvl;
+      let lvl = spells[i].system.lvl;
       if (!sortedSpells[lvl]) sortedSpells[lvl] = [];
       if (!slots[lvl]) slots[lvl] = 0;
-      slots[lvl] += spells[i].data.data.memorized;
+      slots[lvl] += spells[i].system.memorized;
       sortedSpells[lvl].push(spells[i]);
     }
     data.slots = {
       used: slots,
     };
     containers.map((container, key, arr) => {
-      arr[key].data.data.itemIds = containerContents[container.id] || [];
-      arr[key].data.data.totalWeight = containerContents[container.id]?.reduce(
+      arr[key].system.itemIds = containerContents[container.id] || [];
+      arr[key].system.totalWeight = containerContents[container.id]?.reduce(
         (acc, item) => {
           return (
-            acc +
-            item.data?.data?.weight * (item.data?.data?.quantity?.value || 1)
+            acc + item.system?.weight * (item.system?.quantity?.value || 1)
           );
         },
         0
@@ -122,20 +118,22 @@ export class OseActorSheetMonster extends OseActorSheet {
     });
     // Assign and return
     data.owned = { weapons, items, containers, armors, treasures };
-    
+
     data.attackPatterns = attackPatterns;
     // Sort items and spells alphabetically within their groups
     data.spells = sortedSpells;
-    [
-      ...Object.values(data.owned),
-      ...Object.values(data.spells),
-    ].forEach((o) => o.sort((a, b) => a.data.name.localeCompare(b.data.name)));
+    [...Object.values(data.owned), ...Object.values(data.spells)].forEach((o) =>
+      o.sort((a, b) => a.data.name.localeCompare(b.data.name))
+    );
 
-    // Within each attack pattern, weapons come before abilities, 
+    // Within each attack pattern, weapons come before abilities,
     // and are then alphabetized
-    Object.values(data.attackPatterns).forEach(
-        (o) => o.sort((a, b) => 
-        b.data.type.localeCompare(a.data.type) || a.data.name.localeCompare(b.data.name))
+    Object.values(data.attackPatterns).forEach((o) =>
+      o.sort(
+        (a, b) =>
+          b.data.type.localeCompare(a.data.type) ||
+          a.data.name.localeCompare(b.data.name)
+      )
     );
   }
 
@@ -148,7 +146,7 @@ export class OseActorSheetMonster extends OseActorSheet {
     // Prepare owned items
     this._prepareItems(data);
 
-    const monsterData = data?.system || data?.data; //v9-compatibility
+    const monsterData = data?.system;
 
     // Settings
     data.config.morale = game.settings.get(game.system.id, "morale");
@@ -224,22 +222,21 @@ export class OseActorSheetMonster extends OseActorSheet {
     } else {
       link = `@UUID[${data.uuid}]`;
     }
-    const treasureTableKey = isNewerVersion(game.version, "10.264")
-      ? "system.details.treasure.table"
-      : "data.details.treasure.table"; //v9-compatibility
+    // @TODO: isn't there a better place for defining this treasureTableKey const
+    const treasureTableKey = "system.details.treasure.table";
     this.actor.update({ [treasureTableKey]: link });
   }
 
   /* -------------------------------------------- */
   async _resetAttacks(event) {
-    const monsterItems = this.actor?.items || this.actor?.data?.items; //v9-compatiblity
+    const monsterItems = this.actor?.items;
     const weapons = monsterItems.filter((i) => i.type === "weapon");
     for (let wp of weapons) {
       const item = this.actor.items.get(wp.id);
       await item.update({
         data: {
           counter: {
-            value: parseInt(wp.data.data.counter.max),
+            value: parseInt(wp.system.counter.max),
           },
         },
       });
@@ -263,7 +260,7 @@ export class OseActorSheetMonster extends OseActorSheet {
 
   _cycleAttackPatterns(event) {
     const item = super._getItemFromActor(event);
-    let currentColor = item.data.data.pattern;
+    let currentColor = item.system.pattern;
     // Attack patterns include all OSE colors and transparent
     let colors = Object.keys(CONFIG.OSE.colors);
     colors.push("transparent");
@@ -302,9 +299,7 @@ export class OseActorSheetMonster extends OseActorSheet {
     });
 
     html.find(".treasure-table a").contextmenu((ev) => {
-      const treasureTableKey = isNewerVersion(game.version, "10.264")
-        ? "system.details.treasure.table"
-        : "data.details.treasure.table"; //v9-compatibility
+      const treasureTableKey = "system.details.treasure.table";
       this.actor.update({ [treasureTableKey]: null });
     });
 

--- a/src/module/actor/monster-sheet.js
+++ b/src/module/actor/monster-sheet.js
@@ -171,7 +171,7 @@ export class OseActorSheetMonster extends OseActorSheet {
   async generateSave() {
     let choices = CONFIG.OSE.monster_saves;
 
-    let templateData = { choices: choices },
+    let templateData = { choices },
       dlg = await renderTemplate(
         `${OSE.systemPath()}/templates/actors/dialogs/monster-saves.html`,
         templateData

--- a/src/module/actor/monster-sheet.js
+++ b/src/module/actor/monster-sheet.js
@@ -123,7 +123,7 @@ export class OseActorSheetMonster extends OseActorSheet {
     // Sort items and spells alphabetically within their groups
     data.spells = sortedSpells;
     [...Object.values(data.owned), ...Object.values(data.spells)].forEach((o) =>
-      o.sort((a, b) => a.data.name.localeCompare(b.data.name))
+      o.sort((a, b) => a.name.localeCompare(b.name))
     );
 
     // Within each attack pattern, weapons come before abilities,
@@ -131,8 +131,8 @@ export class OseActorSheetMonster extends OseActorSheet {
     Object.values(data.attackPatterns).forEach((o) =>
       o.sort(
         (a, b) =>
-          b.data.type.localeCompare(a.data.type) ||
-          a.data.name.localeCompare(b.data.name)
+          b.type.localeCompare(a.type) ||
+          a.name.localeCompare(b.name)
       )
     );
   }
@@ -249,11 +249,11 @@ export class OseActorSheetMonster extends OseActorSheet {
 
     if (event.target.dataset.field === "value") {
       return item.update({
-        "data.counter.value": parseInt(event.target.value),
+        "system.counter.value": parseInt(event.target.value),
       });
     } else if (event.target.dataset.field === "max") {
       return item.update({
-        "data.counter.max": parseInt(event.target.value),
+        "system.counter.max": parseInt(event.target.value),
       });
     }
   }
@@ -271,7 +271,7 @@ export class OseActorSheetMonster extends OseActorSheet {
       index++;
     }
     item.update({
-      "data.pattern": colors[index],
+      "system.pattern": colors[index],
     });
   }
 

--- a/src/module/actor/monster-sheet.js
+++ b/src/module/actor/monster-sheet.js
@@ -227,18 +227,13 @@ export class OseActorSheetMonster extends OseActorSheet {
 
   /* -------------------------------------------- */
   async _resetAttacks(event) {
-    const monsterItems = this.actor?.items;
-    const weapons = monsterItems.filter((i) => i.type === "weapon");
-    for (let wp of weapons) {
-      const item = this.actor.items.get(wp.id);
-      await item.update({
-        data: {
-          counter: {
-            value: parseInt(wp.system.counter.max),
-          },
-        },
-      });
-    }
+    return Promise.all(
+      this.actor.items
+        .filter(i => i.type === 'weapon')
+        .map(weapon => weapon.update({
+          'system.counter.value': parseInt(weapon.system.counter.max)
+        }))
+    )
   }
 
   async _updateAttackCounter(event) {

--- a/src/module/actor/monster-sheet.js
+++ b/src/module/actor/monster-sheet.js
@@ -222,9 +222,7 @@ export class OseActorSheetMonster extends OseActorSheet {
     } else {
       link = `@UUID[${data.uuid}]`;
     }
-    // @TODO: isn't there a better place for defining this treasureTableKey const
-    const treasureTableKey = "system.details.treasure.table";
-    this.actor.update({ [treasureTableKey]: link });
+    this.actor.update({ 'system.details.treasure.table': link });
   }
 
   /* -------------------------------------------- */
@@ -299,8 +297,7 @@ export class OseActorSheetMonster extends OseActorSheet {
     });
 
     html.find(".treasure-table a").contextmenu((ev) => {
-      const treasureTableKey = "system.details.treasure.table";
-      this.actor.update({ [treasureTableKey]: null });
+      this.actor.update({ 'system.details.treasure.table': null });
     });
 
     // Everything below here is only needed if the sheet is editable

--- a/src/module/actor/monster-sheet.js
+++ b/src/module/actor/monster-sheet.js
@@ -218,7 +218,7 @@ export class OseActorSheetMonster extends OseActorSheet {
       let tableData = game.packs
         .get(data.pack)
         .index.filter((el) => el._id === data.id);
-      link = `@Compendium[${data.pack}.${data.id}]{${tableData[0].name}}`;
+      link = `@UUID[${data.uuid}]{${tableData[0].name}}`;
     } else {
       link = `@UUID[${data.uuid}]`;
     }

--- a/src/module/chat.ts
+++ b/src/module/chat.ts
@@ -35,7 +35,6 @@ export const addChatMessageButtons = function (msg: ChatMessage, html: JQuery) {
   if (
     // @ts-ignore need to add ChatMessage document property updates.
     msg?.blind &&
-    msg?.data?.blind && //v9 compatibility
     !game.user?.isGM &&
     blindable &&
     blindable.data("blind") === true

--- a/src/module/combat.js
+++ b/src/module/combat.js
@@ -17,7 +17,7 @@ export class OseCombat {
     // Check groups
     data.combatants = [];
     let groups = {};
-    let combatants = combat?.combatants || combat?.data?.combatants; //v9-compatibility
+    let combatants = combat?.combatants;
     combatants.forEach((cbt) => {
       const group = cbt.getFlag(game.system.id, "group");
       groups[group] = { present: true };
@@ -41,9 +41,7 @@ export class OseCombat {
         if (!data.combatants[i].actor) {
           return;
         }
-        let actorData =
-          data.combatants[i].actor?.system ||
-          data.combatants[i].actor?.data?.data;
+        let actorData = data.combatants[i].actor?.system;
         if (actorData.isSlow) {
           await data.combatants[i].update({
             initiative: OseCombat.STATUS_SLOW,
@@ -72,7 +70,7 @@ export class OseCombat {
   static async individualInitiative(combat, data) {
     let updates = [];
     let rolls = [];
-    let combatants = combat?.combatants || combat?.data?.data; //v9-compatibility
+    let combatants = combat?.combatants;
     for (let i = 0; i < combatants.size; i++) {
       let c = combatants.contents[i];
       // This comes from foundry.js, had to remove the update turns thing
@@ -98,10 +96,9 @@ export class OseCombat {
       );
       //add initiative value to update
       //check if actor is slow
-      let value =
-        cbt.actor?.system?.isSlow || cbt.actor?.data?.data?.isSlow //v9-compatibility
-          ? OseCombat.STATUS_SLOW
-          : roll.total;
+      let value = cbt.actor?.system?.isSlow
+        ? OseCombat.STATUS_SLOW
+        : roll.total;
       //check if actor is defeated
       if (combat.settings.skipDefeated && cbt.isDefeated) {
         value = OseCombat.STATUS_DIZZY;
@@ -202,7 +199,7 @@ export class OseCombat {
   static updateCombatant(combatant, data) {
     let init = game.settings.get(game.system.id, "initiative");
     // Why do you reroll ?
-    const actorData = combatant.actor?.system || combatant.actor?.data?.data;
+    const actorData = combatant.actor?.system;
     if (actorData.isSlow) {
       data.initiative = -789;
       return;

--- a/src/module/dialog/character-gp-cost.js
+++ b/src/module/dialog/character-gp-cost.js
@@ -54,7 +54,7 @@ export class OseCharacterGpCost extends FormApplication {
     // Generate gold
     const totalCost = await this._getTotalCost(await this.getData());
     const gp = await this.object.items.find((item) => {
-      itemData = item?.system;
+      itemData = item.system;
       return (
         (item.name === game.i18n.localize("OSE.items.gp.short") ||
           item.name === "GP") && // legacy behavior used GP, even for other languages
@@ -105,7 +105,7 @@ export class OseCharacterGpCost extends FormApplication {
     let total = 0;
     const physical = ["item", "container", "weapon", "armor"];
     data.items.forEach((item) => {
-      const itemData = item?.system;
+      const itemData = item.system;
       if (
         physical.some((itemType) => item.type === itemType) &&
         !itemData.treasure

--- a/src/module/dialog/character-gp-cost.js
+++ b/src/module/dialog/character-gp-cost.js
@@ -67,7 +67,7 @@ export class OseCharacterGpCost extends FormApplication {
     const newGP = gp.system.quantity.value - totalCost;
     if (newGP >= 0) {
       this.object.updateEmbeddedDocuments("Item", [
-        { _id: gp.id, "data.quantity.value": newGP },
+        { _id: gp.id, "system.quantity.value": newGP },
       ]);
     } else {
       ui.notifications.error(game.i18n.localize("OSE.error.notEnoughGP"));

--- a/src/module/dialog/character-gp-cost.js
+++ b/src/module/dialog/character-gp-cost.js
@@ -54,7 +54,7 @@ export class OseCharacterGpCost extends FormApplication {
     // Generate gold
     const totalCost = await this._getTotalCost(await this.getData());
     const gp = await this.object.items.find((item) => {
-      itemData = item?.system || item?.data?.data; //v9-compatibility
+      itemData = item?.system;
       return (
         (item.name === game.i18n.localize("OSE.items.gp.short") ||
           item.name === "GP") && // legacy behavior used GP, even for other languages
@@ -64,7 +64,7 @@ export class OseCharacterGpCost extends FormApplication {
     if (!gp) {
       ui.notifications.error(game.i18n.localize("OSE.error.noGP"));
     }
-    const newGP = gp.data.data.quantity.value - totalCost;
+    const newGP = gp.system.quantity.value - totalCost;
     if (newGP >= 0) {
       this.object.updateEmbeddedDocuments("Item", [
         { _id: gp.id, "data.quantity.value": newGP },
@@ -105,7 +105,7 @@ export class OseCharacterGpCost extends FormApplication {
     let total = 0;
     const physical = ["item", "container", "weapon", "armor"];
     data.items.forEach((item) => {
-      const itemData = item?.system || item?.data?.data;
+      const itemData = item?.system;
       if (
         physical.some((itemType) => item.type === itemType) &&
         !itemData.treasure

--- a/src/module/dice.js
+++ b/src/module/dice.js
@@ -153,7 +153,7 @@ export class OseDice {
     let targetActorData = data.roll.target?.actor?.system || null;
 
     const targetAc = data.roll.target ? targetActorData.ac.value : 9;
-    const targetAac = data.roll.target ? targetActorData.aac.value : 0;
+    const targetAac = data.roll.target ? targetActorData.aac.value : 10;
     result.victim = data.roll.target ? data.roll.target.name : null;
 
     if (game.settings.get(game.system.id, "ascendingAC")) {

--- a/src/module/dice.js
+++ b/src/module/dice.js
@@ -154,7 +154,7 @@ export class OseDice {
 
     const targetAc = data.roll.target ? targetActorData.ac.value : 9;
     const targetAac = data.roll.target ? targetActorData.aac.value : 0;
-    result.victim = data.roll.target ? data.roll.target.data.name : null;
+    result.victim = data.roll.target ? data.roll.target.name : null;
 
     if (game.settings.get(game.system.id, "ascendingAC")) {
       if (

--- a/src/module/dice.js
+++ b/src/module/dice.js
@@ -150,10 +150,7 @@ export class OseDice {
       total: roll.total,
     };
     result.target = data.roll.thac0;
-    let targetActorData =
-      data.roll.target?.actor?.system ||
-      data.roll.target?.actor?.data?.data ||
-      null; //v9-compatibility
+    let targetActorData = data.roll.target?.actor?.system || null;
 
     const targetAc = data.roll.target ? targetActorData.ac.value : 9;
     const targetAac = data.roll.target ? targetActorData.aac.value : 0;

--- a/src/module/fvttModuleAPIs.js
+++ b/src/module/fvttModuleAPIs.js
@@ -1,10 +1,11 @@
 export const registerFVTTModuleAPIs = () => {
   // see docs for more info https://github.com/fantasycalendar/FoundryVTT-ItemPiles/blob/master/docs/api.md
   Hooks.once("item-piles-ready", async function () {
+    // @TODO: confirm with Wasp that this API should function in V10-compatible ItemPiles
     if (ItemPiles.API.ACTOR_CLASS_TYPE !== "character")
       ItemPiles.API.setActorClassType("character");
-    if (ItemPiles.API.ITEM_QUANTITY_ATTRIBUTE !== "data.quantity.value")
-      ItemPiles.API.setItemQuantityAttribute("data.quantity.value");
+    if (ItemPiles.API.ITEM_QUANTITY_ATTRIBUTE !== "system.quantity.value")
+      ItemPiles.API.setItemQuantityAttribute("system.quantity.value");
     if (
       ItemPiles.API.ITEM_FILTERS !==
       [

--- a/src/module/helpers.ts
+++ b/src/module/helpers.ts
@@ -68,9 +68,4 @@ export const registerHelpers = async function () {
   Handlebars.registerHelper("parseInline", function (html) {
     return TextEditor.enrichHTML(html);
   });
-
-  // helper for v9 compatibility
-  Handlebars.registerHelper("isV10", function () {
-    return isNewerVersion(game.release.version, "10.264");
-  });
 };

--- a/src/module/item/entity.js
+++ b/src/module/item/entity.js
@@ -29,7 +29,7 @@ export class OseItem extends Item {
   }
 
   async prepareDerivedData() {
-    const itemData = this?.system || this?.data?.data; //v9-compatibility
+    const itemData = this?.system;
     itemData.autoTags = this.getAutoTagList();
     itemData.manualTags = itemData.tags;
 
@@ -53,9 +53,9 @@ export class OseItem extends Item {
   }
 
   async getChatData(htmlOptions) {
-    const itemType = this?.type || this?.data?.type; //v9-compatibility
+    const itemType = this?.type;
 
-    const itemData = this?.system || this?.data?.data; //v9-compatibility
+    const itemData = this?.system;
 
     // Item properties
     const props = [];
@@ -82,12 +82,12 @@ export class OseItem extends Item {
   rollWeapon(options = {}) {
     let isNPC = this.actor.data.type != "character";
     const targets = 5;
-    const itemData = this?.system || this?.data?.data; //v9-compatibility
+    const itemData = this?.system;
 
     let type = isNPC ? "attack" : "melee";
     const rollData = {
-      item: this.data,
-      actor: this.actor.data,
+      item: this,
+      actor: this.actor,
       roll: {
         save: itemData.save,
         target: null,
@@ -126,7 +126,7 @@ export class OseItem extends Item {
   }
 
   async rollFormula(options = {}) {
-    const data = this?.system || this?.data?.data; //v9-compatibility
+    const data = this?.system;
 
     if (!data.roll) {
       throw new Error("This Item does not have a formula to roll!");
@@ -138,8 +138,8 @@ export class OseItem extends Item {
     let type = data.rollType;
 
     const newData = {
-      actor: this.actor.data,
-      item: this.data,
+      actor: this.actor,
+      item: this,
       roll: {
         type: type,
         target: data.rollTarget,
@@ -160,7 +160,7 @@ export class OseItem extends Item {
   }
 
   spendSpell() {
-    const itemData = this?.system || this?.data?.data; //v9-compatibility
+    const itemData = this?.system;
     this.update({
       data: {
         cast: itemData.cast - 1,
@@ -196,8 +196,8 @@ export class OseItem extends Item {
 
   getAutoTagList() {
     const tagList = [];
-    const data = this?.system || this?.data?.data; //v9-compatibility
-    const itemType = this?.type || this?.data?.type; //v9-compatibility
+    const data = this?.system;
+    const itemType = this?.type;
 
     switch (itemType) {
       case "container":
@@ -247,7 +247,7 @@ export class OseItem extends Item {
   }
 
   pushManualTag(values) {
-    const data = this?.system || this?.data?.data; //v9-compatibility
+    const data = this?.system;
 
     let update = [];
     if (data.tags) {
@@ -289,7 +289,7 @@ export class OseItem extends Item {
   }
 
   popManualTag(value) {
-    const itemData = this?.system || this?.data?.data; //v9-compatibility
+    const itemData = this?.system;
 
     const tags = itemData.tags;
     if (!tags) return;
@@ -302,7 +302,7 @@ export class OseItem extends Item {
   }
 
   roll(options = {}) {
-    const itemData = this?.system || this?.data?.data; //v9-compatibility
+    const itemData = this?.system;
     switch (this.type) {
       case "weapon":
         this.rollWeapon(options);
@@ -328,13 +328,13 @@ export class OseItem extends Item {
    * @return {Promise}
    */
   async show() {
-    const itemType = this?.type || this?.data?.type; //v9-compatibility
+    const itemType = this?.type;
     // Basic template rendering data
     const token = this.actor.token; //v10: prototypeToken?
     const templateData = {
       actor: this.actor,
       tokenId: token ? `${token.parent.id}.${token.id}` : null,
-      item: this.data,
+      item: this,
       data: await this.getChatData(),
       labels: this.labels,
       isHealing: this.isHealing,

--- a/src/module/item/entity.js
+++ b/src/module/item/entity.js
@@ -86,7 +86,7 @@ export class OseItem extends Item {
 
     let type = isNPC ? "attack" : "melee";
     const rollData = {
-      item: this,
+      item: this._source,
       actor: this.actor,
       roll: {
         save: itemData.save,
@@ -139,7 +139,7 @@ export class OseItem extends Item {
 
     const newData = {
       actor: this.actor,
-      item: this,
+      item: this._source,
       roll: {
         type: type,
         target: data.rollTarget,
@@ -334,7 +334,7 @@ export class OseItem extends Item {
     const templateData = {
       actor: this.actor,
       tokenId: token ? `${token.parent.id}.${token.id}` : null,
-      item: this,
+      item: this._source,
       data: await this.getChatData(),
       labels: this.labels,
       isHealing: this.isHealing,

--- a/src/module/item/entity.js
+++ b/src/module/item/entity.js
@@ -80,7 +80,7 @@ export class OseItem extends Item {
   }
 
   rollWeapon(options = {}) {
-    let isNPC = this.actor.data.type != "character";
+    let isNPC = this.actor.type != "character";
     const targets = 5;
     const itemData = this?.system;
 

--- a/src/module/item/entity.js
+++ b/src/module/item/entity.js
@@ -29,7 +29,7 @@ export class OseItem extends Item {
   }
 
   async prepareDerivedData() {
-    const itemData = this?.system;
+    const itemData = this.system;
     itemData.autoTags = this.getAutoTagList();
     itemData.manualTags = itemData.tags;
 
@@ -53,9 +53,9 @@ export class OseItem extends Item {
   }
 
   async getChatData(htmlOptions) {
-    const itemType = this?.type;
+    const itemType = this.type;
 
-    const itemData = this?.system;
+    const itemData = this.system;
 
     // Item properties
     const props = [];
@@ -82,7 +82,7 @@ export class OseItem extends Item {
   rollWeapon(options = {}) {
     let isNPC = this.actor.type != "character";
     const targets = 5;
-    const itemData = this?.system;
+    const itemData = this.system;
 
     let type = isNPC ? "attack" : "melee";
     const rollData = {
@@ -126,7 +126,7 @@ export class OseItem extends Item {
   }
 
   async rollFormula(options = {}) {
-    const data = this?.system;
+    const data = this.system;
 
     if (!data.roll) {
       throw new Error("This Item does not have a formula to roll!");
@@ -160,7 +160,7 @@ export class OseItem extends Item {
   }
 
   spendSpell() {
-    const itemData = this?.system;
+    const itemData = this.system;
     this.update({
       data: {
         cast: itemData.cast - 1,
@@ -196,8 +196,8 @@ export class OseItem extends Item {
 
   getAutoTagList() {
     const tagList = [];
-    const data = this?.system;
-    const itemType = this?.type;
+    const data = this.system;
+    const itemType = this.type;
 
     switch (itemType) {
       case "container":
@@ -247,7 +247,7 @@ export class OseItem extends Item {
   }
 
   pushManualTag(values) {
-    const data = this?.system;
+    const data = this.system;
 
     let update = [];
     if (data.tags) {
@@ -289,7 +289,7 @@ export class OseItem extends Item {
   }
 
   popManualTag(value) {
-    const itemData = this?.system;
+    const itemData = this.system;
 
     const tags = itemData.tags;
     if (!tags) return;
@@ -302,7 +302,7 @@ export class OseItem extends Item {
   }
 
   roll(options = {}) {
-    const itemData = this?.system;
+    const itemData = this.system;
     switch (this.type) {
       case "weapon":
         this.rollWeapon(options);
@@ -328,7 +328,7 @@ export class OseItem extends Item {
    * @return {Promise}
    */
   async show() {
-    const itemType = this?.type;
+    const itemType = this.type;
     // Basic template rendering data
     const token = this.actor.token; //v10: prototypeToken?
     const templateData = {

--- a/src/module/item/item-sheet.js
+++ b/src/module/item/item-sheet.js
@@ -72,11 +72,11 @@ export class OseItemSheet extends ItemSheet {
       this.object.popManualTag(value);
     });
     html.find("a.melee-toggle").click(() => {
-      this.object.update({ data: { melee: !this.object.data.data.melee } });
+      this.object.update({ data: { melee: !this.object.system.melee } });
     });
 
     html.find("a.missile-toggle").click(() => {
-      this.object.update({ data: { missile: !this.object.data.data.missile } });
+      this.object.update({ data: { missile: !this.object.system.missile } });
     });
 
     super.activateListeners(html);

--- a/src/module/item/item-sheet.js
+++ b/src/module/item/item-sheet.js
@@ -72,11 +72,11 @@ export class OseItemSheet extends ItemSheet {
       this.object.popManualTag(value);
     });
     html.find("a.melee-toggle").click(() => {
-      this.object.update({ data: { melee: !this.object.system.melee } });
+      this.object.update({ 'system.melee': !this.object.system.melee });
     });
 
     html.find("a.missile-toggle").click(() => {
-      this.object.update({ data: { missile: !this.object.system.missile } });
+      this.object.update({ 'system.missile': !this.object.system.missile })
     });
 
     super.activateListeners(html);

--- a/src/module/item/item-sheet.js
+++ b/src/module/item/item-sheet.js
@@ -38,7 +38,7 @@ export class OseItemSheet extends ItemSheet {
   /** @override */
   get template() {
     const path = `${OSE.systemPath()}/templates/items`;
-    const type = isNewerVersion(game.version, "10.264") ? this.item.type : this.item.data.type
+    const type = isNewerVersion(game.version, "10.264") ? this.item.type : this.item.type
     return `${path}/${type}-sheet.html`;
   }
 

--- a/src/module/macros.js
+++ b/src/module/macros.js
@@ -15,7 +15,7 @@ export async function createOseMacro(data, slot) {
     return ui.notifications.warn(
       game.i18.localize("OSE.warn.macrosOnlyForOwnedItems")
     );
-  const item = data;
+  const item = data.data;
 
   // Create the macro command
   const command = `game.ose.rollItemMacro("${item.name}");`;

--- a/src/module/macros.js
+++ b/src/module/macros.js
@@ -15,7 +15,7 @@ export async function createOseMacro(data, slot) {
     return ui.notifications.warn(
       game.i18.localize("OSE.warn.macrosOnlyForOwnedItems")
     );
-  const item = data.data;
+  const item = data;
 
   // Create the macro command
   const command = `game.ose.rollItemMacro("${item.name}");`;

--- a/src/module/party/party-xp.js
+++ b/src/module/party/party-xp.js
@@ -65,7 +65,7 @@ export class OsePartyXP extends FormApplication {
     const baseXpShare = parseFloat(totalXP) / currentParty.length;
 
     currentParty.forEach((a) => {
-      const actorData = a?.system || a?.data.data; //v9-compatibility
+      const actorData = a?.system;
       const xpShare = Math.floor(
         (actorData.details.xp.share / 100) * baseXpShare
       );

--- a/src/module/party/party.js
+++ b/src/module/party/party.js
@@ -1,3 +1,5 @@
+import {OSE} from '../config';
+
 export class OseParty {
   /**
    * @public
@@ -5,12 +7,11 @@ export class OseParty {
    * @return {OseActor[]}
    */
   static get currentParty() {
-    const systemName = game.system.id == "ose" ? game.system.id : "ose-dev";
     const characters = game.actors.filter(
       (act) =>
         act.type === "character" &&
-        act.flags[systemName] &&
-        act.flags[systemName].party === true
+        act.flags[OSE.systemName] &&
+        act.flags[OSE.systemName].party === true
     );
     return characters;
   }

--- a/src/module/party/party.js
+++ b/src/module/party/party.js
@@ -5,20 +5,14 @@ export class OseParty {
    * @return {OseActor[]}
    */
   static get currentParty() {
-    const v10 = isNewerVersion(game.version, "10.264");
-    const systemName = game.system.id == 'ose' ? game.system.id : 'ose-dev'
-    const characters = v10 ?
-      game.actors.filter(
-        (act) =>
-          act.type === "character" &&
-          act.flags[systemName] &&
-          act.flags[systemName].party === true) :
-      game.actors.filter(
-        (act) =>
-          act.data.type === "character" &&
-          act.data.flags[systemName] &&
-          act.data.flags[systemName].party === true);
-    console.log(characters)
+    const systemName = game.system.id == "ose" ? game.system.id : "ose-dev";
+    const characters = game.actors.filter(
+      (act) =>
+        act.type === "character" &&
+        act.flags[systemName] &&
+        act.flags[systemName].party === true
+    );
+    console.log(characters);
     return characters;
   }
 }

--- a/src/module/party/party.js
+++ b/src/module/party/party.js
@@ -12,7 +12,6 @@ export class OseParty {
         act.flags[systemName] &&
         act.flags[systemName].party === true
     );
-    console.log(characters);
     return characters;
   }
 }

--- a/src/templates/actors/dialogs/character-creation.html
+++ b/src/templates/actors/dialogs/character-creation.html
@@ -10,7 +10,7 @@
         <div class="form-fields">
           <input
             class="score-value"
-            name="data.scores.{{id}}.value"
+            name="system.scores.{{id}}.value"
             type="text"
             value="0"
             data-dtype="Number"

--- a/src/templates/actors/dialogs/gp-cost-dialog.html
+++ b/src/templates/actors/dialogs/gp-cost-dialog.html
@@ -10,7 +10,7 @@
           ></div>
           <h4 class="item-name" title="{{item.name}}">{{item.name~}}</h4>
             <div class="field-short">
-              {{item.data.data.cost}}
+              {{item.system.cost}}
             </div>
           </div>
         </li>
@@ -26,7 +26,7 @@
             ></div>
             <h4 class="item-name" title="{{item.name}}">{{item.name~}}</h4>
               <div class="field-short">
-                {{item.data.data.cost}}
+                {{item.system.cost}}
               </div>
             </div>
           </li>
@@ -42,11 +42,11 @@
             ></div>
             <h4 class="item-name" title="{{bag.name}}">{{bag.name~}}</h4>
               <div class="field-short">
-                {{bag.data.data.cost}}
+                {{bag.system.cost}}
               </div>
             </div>
           </li>
-        {{#each bag.data.data.itemIds as |item|}}
+        {{#each bag.system.itemIds as |item|}}
         <ol>
         <li class="item-entry item" data-item-id="{{item.id}}">
             <div class="item-header flexrow">
@@ -56,7 +56,7 @@
             ></div>
             <h4 class="item-name" title="{{item.name}}">{{item.name~}}</h4>
               <div class="field-short">
-                {{item.data.data.cost}}
+                {{item.system.cost}}
               </div>
             </div>
           </li>
@@ -74,7 +74,7 @@
             ></div>
             <h4 class="item-name" title="{{item.name}}">{{item.name~}}</h4>
               <div class="field-short">
-                {{item.data.data.cost}}
+                {{item.system.cost}}
               </div>
             </div>
           </li>

--- a/src/templates/actors/monster-sheet.html
+++ b/src/templates/actors/monster-sheet.html
@@ -37,11 +37,8 @@
       <div class="inventory">
         <div class="item-category-title">{{localize "OSE.category.notes"}}</div>
         <div class="resizable-editor" data-editor-size="320">
-          {{#if (isV10)}} {{editor enrichedBiography
-          target="system.details.biography" button=true editable=editable
-          async=true}} {{else}} {{editor content=data.details.biography
-          target="data.details.biography" button=true owner=owner
-          editable=editable }} {{/if}}
+          {{editor enrichedBiography target="system.details.biography"
+          button=true editable=editable async=true}}
         </div>
       </div>
     </div>

--- a/src/templates/actors/partials/character-notes-tab.html
+++ b/src/templates/actors/partials/character-notes-tab.html
@@ -32,11 +32,8 @@
       <div class="flex3 description">
         <div class="item-category-title">Biography</div>
         <div>
-          {{#if (isV10)}} {{editor enrichedBiography
-          target="system.details.biography" button=true editable=editable
-          async=true}} {{else}} {{editor content=data.details.biography
-          target="data.details.biography" button=true owner=owner
-          editable=editable}} {{/if}}
+          {{editor enrichedBiography target="system.details.biography"
+          button=true editable=editable async=true}}
         </div>
       </div>
     </div>
@@ -44,10 +41,8 @@
   <div class="inventory notes">
     <div class="item-category-title">{{localize "OSE.category.notes"}}</div>
     <div class="resizable-editor" data-editor-size="140">
-      {{#if (isV10)}} {{editor enrichedNotes target="system.details.notes"
-      button=true editable=editable async=true}} {{else}} {{editor
-      content=data.details.notes target="system.details.notes" button=true
-      owner=owner editable=editable}} {{/if}}
+      {{editor enrichedNotes target="system.details.notes" button=true
+      editable=editable async=true}}
     </div>
   </div>
 </section>

--- a/src/templates/apps/party-sheet.html
+++ b/src/templates/apps/party-sheet.html
@@ -61,7 +61,7 @@
               <i class="fas fa-crosshairs"></i>
               {{e.system.thac0.bba}}
             </div>
-            {{/unless}} {{#if (eq e.data.type 'character')}}
+            {{/unless}} {{#if (eq e.type 'character')}}
             <div class="field-short" title="{{localize 'OSE.Melee'}}">
               <i class="fas fa-fist-raised"></i>
               {{add e.system.scores.str.mod e.system.thac0.mod.melee}}
@@ -83,7 +83,7 @@
                 >{{e.system.movement.base}}</sub
               >
             </div>
-            {{#if (eq e.data.type 'character')}}
+            {{#if (eq e.type 'character')}}
             <div class="field-short flex2">
               <i
                 class="fas fa-weight-hanging"
@@ -99,7 +99,7 @@
               <span title="{{lookup @root.config.saves_long i}}"
                 >{{lookup @root.config.saves_short i}} {{s.value}}</span
               >
-              {{/each}} {{#if (eq e.data.type 'character')}}<span
+              {{/each}} {{#if (eq e.type 'character')}}<span
                 ><i
                   class="fas fa-magic"
                   title="{{localize 'OSE.saves.magic.long'}}"

--- a/src/templates/apps/party-sheet.html
+++ b/src/templates/apps/party-sheet.html
@@ -2,19 +2,22 @@
   <div class="actor header flexrow item-controls">
     <div id="empty"></div>
     {{#if user.isGM}}
-    <button id="deal-xp" class="item-control" type="button" title="{{localize 'OSE.dialog.xp.deal'}}">
+    <button
+      id="deal-xp"
+      class="item-control"
+      type="button"
+      title="{{localize 'OSE.dialog.xp.deal'}}"
+    >
       {{localize 'OSE.dialog.xp.label'}}
     </button>
     {{/if}}
   </div>
   <div class="body party-members">
-    {{#if user.isGM}}
-    {{#if (eq partyActors.length 0)}}
+    {{#if user.isGM}} {{#if (eq partyActors.length 0)}}
     <div class="drag-drop-placeholder">
       <p>{{localize 'OSE.dialog.partysheetplaceholder'}}</p>
     </div>
-    {{/if}}
-    {{/if}}
+    {{/if}} {{/if}}
     <ol class="actor-list">
       {{#each partyActors as |e|}}
       <li class="actor flexrow" data-actor-id="{{e.id}}">
@@ -34,14 +37,16 @@
             <div title="{{e.name}}" class="field-name flex2">{{e.name}}</div>
             <div class="field-long" title="{{localize 'OSE.Health'}}">
               <i class="fas fa-heart"></i>
-              {{e.data.data.hp.value}}/{{e.data.data.hp.max}}
+              {{e.system.hp.value}}/{{e.system.hp.max}}
             </div>
             <div class="field-short" title="{{localize 'OSE.ArmorClass'}}">
               <i class="fas fa-shield-alt"></i>
-              {{#if @root.settings.ascending}}<strong>{{e.data.data.aac.value}}</strong>
-              <sub>{{e.data.data.aac.naked}}</sub>
-              {{else}}<strong>{{e.data.data.ac.value}}</strong>
-              <sub>{{e.data.data.ac.naked}}</sub>
+              {{#if @root.settings.ascending}}<strong
+                >{{e.system.aac.value}}</strong
+              >
+              <sub>{{e.system.aac.naked}}</sub>
+              {{else}}<strong>{{e.system.ac.value}}</strong>
+              <sub>{{e.system.ac.naked}}</sub>
               {{/if}}
             </div>
           </div>
@@ -49,42 +54,58 @@
             {{#unless @root.settings.ascending}}
             <div class="field-short" title="{{localize 'OSE.Thac0'}}">
               <i class="fas fa-crosshairs"></i>
-              {{e.data.data.thac0.value}}
+              {{e.system.thac0.value}}
             </div>
             {{else}}
             <div class="field-short" title="{{localize 'OSE.AB'}}">
               <i class="fas fa-crosshairs"></i>
-              {{e.data.data.thac0.bba}}
+              {{e.system.thac0.bba}}
             </div>
             {{/unless}} {{#if (eq e.data.type 'character')}}
             <div class="field-short" title="{{localize 'OSE.Melee'}}">
               <i class="fas fa-fist-raised"></i>
-              {{add e.data.data.scores.str.mod e.data.data.thac0.mod.melee}}
+              {{add e.system.scores.str.mod e.system.thac0.mod.melee}}
             </div>
             <div class="field-short" title="{{localize 'OSE.Missile'}}">
               <i class="fas fa-bullseye"></i>
-              {{add e.data.data.scores.dex.mod e.data.data.thac0.mod.missile}}
+              {{add e.system.scores.dex.mod e.system.thac0.mod.missile}}
             </div>
             {{/if}}
             <div class="field-short flex2">
-              <i class="fas fa-shoe-prints" title="{{localize 'OSE.movement.base'}}"></i>
-              <span title="{{localize 'OSE.movement.encounter.long'}}">{{e.data.data.movement.encounter}}</span>
-              <sub title="{{localize 'OSE.movement.exploration.long'}}">{{e.data.data.movement.base}}</sub>
+              <i
+                class="fas fa-shoe-prints"
+                title="{{localize 'OSE.movement.base'}}"
+              ></i>
+              <span title="{{localize 'OSE.movement.encounter.long'}}"
+                >{{e.system.movement.encounter}}</span
+              >
+              <sub title="{{localize 'OSE.movement.exploration.long'}}"
+                >{{e.system.movement.base}}</sub
+              >
             </div>
             {{#if (eq e.data.type 'character')}}
             <div class="field-short flex2">
-              <i class="fas fa-weight-hanging" title="{{localize 'OSE.Encumbrance'}}"></i>
-              {{roundWeight e.data.data.encumbrance.value}}k
+              <i
+                class="fas fa-weight-hanging"
+                title="{{localize 'OSE.Encumbrance'}}"
+              ></i>
+              {{roundWeight e.system.encumbrance.value}}k
             </div>
             {{/if}}
           </div>
           <div class="flexrow field-row">
             <div class="field-longer flexrow">
-              {{#each e.data.data.saves as |s i|}}
-              <span title="{{lookup @root.config.saves_long i}}">{{lookup @root.config.saves_short i}}
-                {{s.value}}</span>
-              {{/each}} {{#if (eq e.data.type 'character')}}<span><i class="fas fa-magic"
-                  title="{{localize 'OSE.saves.magic.long'}}"></i>{{mod e.data.data.scores.wis.mod}}</span>{{/if}}
+              {{#each e.system.saves as |s i|}}
+              <span title="{{lookup @root.config.saves_long i}}"
+                >{{lookup @root.config.saves_short i}} {{s.value}}</span
+              >
+              {{/each}} {{#if (eq e.data.type 'character')}}<span
+                ><i
+                  class="fas fa-magic"
+                  title="{{localize 'OSE.saves.magic.long'}}"
+                ></i
+                >{{mod e.system.scores.wis.mod}}</span
+              >{{/if}}
             </div>
           </div>
         </div>

--- a/src/templates/apps/party-sheet.html
+++ b/src/templates/apps/party-sheet.html
@@ -13,11 +13,11 @@
     {{/if}}
   </div>
   <div class="body party-members">
-    {{#if user.isGM}} {{#if (eq partyActors.length 0)}}
+    {{#if (and user.isGM (eq partyActors.length 0))}}
     <div class="drag-drop-placeholder">
       <p>{{localize 'OSE.dialog.partysheetplaceholder'}}</p>
     </div>
-    {{/if}} {{/if}}
+    {{/if}}
     <ol class="actor-list">
       {{#each partyActors as |e|}}
       <li class="actor flexrow" data-actor-id="{{e.id}}">

--- a/src/templates/apps/party-xp.html
+++ b/src/templates/apps/party-xp.html
@@ -7,14 +7,15 @@
   <ul class="actors">
     {{#each actors as |e|}}
     <li class="actor form-group" data-actor-id="{{e.id}}">
-      <span class="share-tag">{{e.data.data.details.xp.share}}%</span>
+      <span class="share-tag">{{e.system.details.xp.share}}%</span>
       <label title="{{e.name}}">{{e.name}}</label>
       <input name="" placeholder="0" type="number" data-dtype="Number" />
     </li>
     {{/each}}
   </ul>
   <div class="dialog-buttons">
-    <button type="button" data-action="deal-xp"><i class="fas
-          fa-hand-holding"></i> {{localize 'OSE.dialog.xp.deal'}}</button>
+    <button type="button" data-action="deal-xp">
+      <i class="fas fa-hand-holding"></i> {{localize 'OSE.dialog.xp.deal'}}
+    </button>
   </div>
 </form>

--- a/src/templates/chat/inventory-list.html
+++ b/src/templates/chat/inventory-list.html
@@ -19,8 +19,7 @@
             ></div>
             <h4 class="item-name" title="{{item.name}}">{{item.name~}}</h4>
             <div class="field-short">
-              {{localize "OSE.items.Quantity"}}
-              {{item.data.data.quantity.value}}
+              {{localize "OSE.items.Quantity"}} {{item.system.quantity.value}}
             </div>
           </div>
           <div class="item-summary">
@@ -43,8 +42,7 @@
             ></div>
             <h4 class="item-name" title="{{item.name}}">{{item.name~}}</h4>
             <div class="field-short">
-              {{localize "OSE.items.Quantity"}}
-              {{item.data.data.quantity.value}}
+              {{localize "OSE.items.Quantity"}} {{item.system.quantity.value}}
             </div>
           </div>
           <div class="item-summary">
@@ -68,7 +66,7 @@
             ></div>
             <h4 class="item-name" title="{{bag.name}}">{{bag.name~}}</h4>
             <div class="field-short">
-              {{localize "OSE.items.Quantity"}} {{bag.data.data.quantity.value}}
+              {{localize "OSE.items.Quantity"}} {{bag.system.quantity.value}}
             </div>
           </div>
           <div class="item-summary">
@@ -76,7 +74,7 @@
             item=bag}}
           </div>
           <ol class="item-list contained-items">
-            {{#each bag.data.data.itemIds as |item|}}
+            {{#each bag.system.itemIds as |item|}}
             <li class="item-entry item" data-item-id="{{item.id}}">
               <div class="item-header flexrow">
                 <div
@@ -86,7 +84,7 @@
                 <h4 class="item-name" title="{{item.name}}">{{item.name~}}</h4>
                 <div class="field-short">
                   {{localize "OSE.items.Quantity"}}
-                  {{item.data.data.quantity.value}}
+                  {{item.system.quantity.value}}
                 </div>
               </div>
               <div class="item-summary">
@@ -113,8 +111,7 @@
             ></div>
             <h4 class="item-name" title="{{item.name}}">{{item.name~}}</h4>
             <div class="field-short">
-              {{localize "OSE.items.Quantity"}}
-              {{item.data.data.quantity.value}}
+              {{localize "OSE.items.Quantity"}} {{item.system.quantity.value}}
             </div>
           </div>
           <div class="item-summary">
@@ -138,8 +135,7 @@
             ></div>
             <h4 class="item-name" title="{{item.name}}">{{item.name~}}</h4>
             <div class="field-short">
-              {{localize "OSE.items.Quantity"}}
-              {{item.data.data.quantity.value}}
+              {{localize "OSE.items.Quantity"}} {{item.system.quantity.value}}
             </div>
           </div>
           <div class="item-summary">

--- a/src/templates/items/ability-sheet.html
+++ b/src/templates/items/ability-sheet.html
@@ -1,4 +1,3 @@
-{{#if (isV10)}}
 <form class="{{cssClass}}" autocomplete="off">
   <header class="sheet-header">
     <img class="profile-img" src="{{img}}" data-edit="img" title="{{name}}" />
@@ -14,37 +13,57 @@
         <div class="form-group block-input">
           <label>{{localize 'OSE.abilities.Requirements'}}</label>
           <div class="form-fields">
-            <input type="text" name="system.requirements" value="{{system.requirements}}" data-dtype="String" />
+            <input
+              type="text"
+              name="system.requirements"
+              value="{{system.requirements}}"
+              data-dtype="String"
+            />
           </div>
         </div>
         <div class="form-group block-input">
           <label>{{localize 'OSE.items.Roll'}}</label>
           <div class="form-fields">
-            <input type="text" name="system.roll" value="{{system.roll}}" data-dtype="String" />
+            <input
+              type="text"
+              name="system.roll"
+              value="{{system.roll}}"
+              data-dtype="String"
+            />
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'OSE.items.RollType'}}</label>
           <div class="form-fields">
             <select name="system.rollType">
-              {{#select system.rollType}}
-              {{#each config.roll_type as |t a|}}
+              {{#select system.rollType}} {{#each config.roll_type as |t a|}}
               <option value="{{a}}">{{t}}</option>
-              {{/each}}
-              {{/select}}
+              {{/each}} {{/select}}
             </select>
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'OSE.items.RollTarget'}}</label>
           <div class="form-fields">
-            <input type="text" name="system.rollTarget" value="{{system.rollTarget}}" data-dtype="Number" />
+            <input
+              type="text"
+              name="system.rollTarget"
+              value="{{system.rollTarget}}"
+              data-dtype="Number"
+            />
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'OSE.items.BlindRoll'}}</label>
           <div class="form-fields">
-            <input type="checkbox" name="system.blindroll" value="{{system.blindroll}}" {{checked system.blindroll}}  data-dtype="Number"/>
+            <input
+              type="checkbox"
+              name="system.blindroll"
+              value="{{system.blindroll}}"
+              {{checked
+              system.blindroll}}
+              data-dtype="Number"
+            />
           </div>
         </div>
         <div class="form-group">
@@ -55,92 +74,15 @@
               <option value=""></option>
               {{#each config.saves_short as |save a|}}
               <option value="{{a}}">{{save}}</option>
-              {{/each}}
-              {{/select}}
+              {{/each}} {{/select}}
             </select>
           </div>
         </div>
       </div>
       <div class="description">
-        {{editor system.enrichedDescription
-          target="system.description"
-          button=true
-          owner=owner
-          editable=editable
-          async=true
-        }}
+        {{editor system.enrichedDescription target="system.description"
+        button=true owner=owner editable=editable async=true }}
       </div>
     </div>
   </section>
 </form>
-{{else}}
-<form class="{{cssClass}}" autocomplete="off">
-  <header class="sheet-header">
-    <img class="profile-img" src="{{img}}" data-edit="img" title="{{name}}" />
-    <div class="header-col">
-      <h1 class="charname">
-        <input name="name" type="text" value="{{name}}" placeholder="Name" />
-      </h1>
-    </div>
-  </header>
-  <section class="sheet-body">
-    <div class="flexrow">
-      <div class="stats">
-        <div class="form-group block-input">
-          <label>{{localize 'OSE.abilities.Requirements'}}</label>
-          <div class="form-fields">
-            <input type="text" name="data.requirements" value="{{data.requirements}}" data-dtype="String" />
-          </div>
-        </div>
-        <div class="form-group block-input">
-          <label>{{localize 'OSE.items.Roll'}}</label>
-          <div class="form-fields">
-            <input type="text" name="data.roll" value="{{data.roll}}" data-dtype="String" />
-          </div>
-        </div>
-        <div class="form-group">
-          <label>{{localize 'OSE.items.RollType'}}</label>
-          <div class="form-fields">
-            <select name="data.rollType">
-              {{#select data.rollType}}
-              {{#each config.roll_type as |t a|}}
-              <option value="{{a}}">{{t}}</option>
-              {{/each}}
-              {{/select}}
-            </select>
-          </div>
-        </div>
-        <div class="form-group">
-          <label>{{localize 'OSE.items.RollTarget'}}</label>
-          <div class="form-fields">
-            <input type="text" name="data.rollTarget" value="{{data.rollTarget}}" data-dtype="Number" />
-          </div>
-        </div>
-        <div class="form-group">
-          <label>{{localize 'OSE.items.BlindRoll'}}</label>
-          <div class="form-fields">
-            <input type="checkbox" name="data.blindroll" value="{{data.blindroll}}" {{checked data.blindroll}}  data-dtype="Number"/>
-          </div>
-        </div>
-        <div class="form-group">
-          <label>{{localize 'OSE.spells.Save'}}</label>
-          <div class="form-fields">
-            <select name="data.save">
-              {{#select data.save}}
-              <option value=""></option>
-              {{#each config.saves_short as |save a|}}
-              <option value="{{a}}">{{save}}</option>
-              {{/each}}
-              {{/select}}
-            </select>
-          </div>
-        </div>
-      </div>
-      <div class="description">
-        {{editor content=data.description target="data.description" button=true
-        owner=owner editable=editable}}
-      </div>
-    </div>
-  </section>
-</form>
-{{/if}}

--- a/src/templates/items/armor-sheet.html
+++ b/src/templates/items/armor-sheet.html
@@ -1,4 +1,3 @@
-{{#if (isV10)}}
 <form class="{{cssClass}}" autocomplete="off">
   <header class="sheet-header">
     <img class="profile-img" src="{{img}}" data-edit="img" title="{{name}}" />
@@ -7,34 +6,48 @@
         <input name="name" type="text" value="{{name}}" placeholder="Name" />
       </h1>
       <ol class="tag-list">
-          {{#each system.manualTags as |tag|}}
-          <li class="tag" title="{{tag.title}}" data-tag="{{tag.value}}">
-            <span>{{tag.value}}</span>
-            <a class="tag-delete"><i class="fas fa-times"></i></a>
-          </li>
-          {{/each}}
-        </ol>
-    </div>  
+        {{#each system.manualTags as |tag|}}
+        <li class="tag" title="{{tag.title}}" data-tag="{{tag.value}}">
+          <span>{{tag.value}}</span>
+          <a class="tag-delete"><i class="fas fa-times"></i></a>
+        </li>
+        {{/each}}
+      </ol>
+    </div>
   </header>
   <section class="sheet-body">
     <div class="flexrow">
       <div class="stats">
         <div class="form-group">
           <div class="form-fields">
-            <input type="text" data-action="add-tag" title="{{localize 'OSE.items.typeTag'}}"
-              placeholder="{{localize 'OSE.items.enterTag'}}" />
+            <input
+              type="text"
+              data-action="add-tag"
+              title="{{localize 'OSE.items.typeTag'}}"
+              placeholder="{{localize 'OSE.items.enterTag'}}"
+            />
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'OSE.items.ArmorAC'}}</label>
           <div class="form-fields">
-            <input type="text" name="system.ac.value" value="{{system.ac.value}}" data-dtype="Number" />
+            <input
+              type="text"
+              name="system.ac.value"
+              value="{{system.ac.value}}"
+              data-dtype="Number"
+            />
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'OSE.items.ArmorAAC'}}</label>
           <div class="form-fields">
-            <input type="text" name="system.aac.value" value="{{system.aac.value}}" data-dtype="Number" />
+            <input
+              type="text"
+              name="system.aac.value"
+              value="{{system.aac.value}}"
+              data-dtype="Number"
+            />
           </div>
         </div>
         <div class="form-group">
@@ -45,101 +58,37 @@
               <option value=""></option>
               {{#each config.armor as |armor a|}}
               <option value="{{a}}">{{armor}}</option>
-              {{/each}}
-              {{/select}}
+              {{/each}} {{/select}}
             </select>
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'OSE.items.Cost'}}</label>
           <div class="form-fields">
-            <input type="text" name="system.cost" value="{{system.cost}}" data-dtype="Number" />
+            <input
+              type="text"
+              name="system.cost"
+              value="{{system.cost}}"
+              data-dtype="Number"
+            />
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'OSE.items.Weight'}}</label>
           <div class="form-fields">
-            <input type="text" name="system.weight" value="{{system.weight}}" data-dtype="Number" />
+            <input
+              type="text"
+              name="system.weight"
+              value="{{system.weight}}"
+              data-dtype="Number"
+            />
           </div>
         </div>
       </div>
       <div class="description">
-        {{editor system.enrichedDescription target="system.description" button=true
-        owner=owner editable=editable async=true}}
+        {{editor system.enrichedDescription target="system.description"
+        button=true owner=owner editable=editable async=true}}
       </div>
     </div>
   </section>
 </form>
-{{else}}
-<form class="{{cssClass}}" autocomplete="off">
-  <header class="sheet-header">
-    <img class="profile-img" src="{{img}}" data-edit="img" title="{{name}}" />
-    <div class="header-col">
-      <h1 class="charname">
-        <input name="name" type="text" value="{{name}}" placeholder="Name" />
-      </h1>
-      <ol class="tag-list">
-          {{#each data.manualTags as |tag|}}
-          <li class="tag" title="{{tag.title}}" data-tag="{{tag.value}}">
-            <span>{{tag.value}}</span>
-            <a class="tag-delete"><i class="fas fa-times"></i></a>
-          </li>
-          {{/each}}
-        </ol>
-    </div>  
-  </header>
-  <section class="sheet-body">
-    <div class="flexrow">
-      <div class="stats">
-        <div class="form-group">
-          <div class="form-fields">
-            <input type="text" data-action="add-tag" title="{{localize 'OSE.items.typeTag'}}"
-              placeholder="{{localize 'OSE.items.enterTag'}}" />
-          </div>
-        </div>
-        <div class="form-group">
-          <label>{{localize 'OSE.items.ArmorAC'}}</label>
-          <div class="form-fields">
-            <input type="text" name="data.ac.value" value="{{data.ac.value}}" data-dtype="Number" />
-          </div>
-        </div>
-        <div class="form-group">
-          <label>{{localize 'OSE.items.ArmorAAC'}}</label>
-          <div class="form-fields">
-            <input type="text" name="data.aac.value" value="{{data.aac.value}}" data-dtype="Number" />
-          </div>
-        </div>
-        <div class="form-group">
-          <label>{{localize 'OSE.armor.type'}}</label>
-          <div class="form-fields">
-            <select name="data.type">
-              {{#select data.type}}
-              <option value=""></option>
-              {{#each config.armor as |armor a|}}
-              <option value="{{a}}">{{armor}}</option>
-              {{/each}}
-              {{/select}}
-            </select>
-          </div>
-        </div>
-        <div class="form-group">
-          <label>{{localize 'OSE.items.Cost'}}</label>
-          <div class="form-fields">
-            <input type="text" name="data.cost" value="{{data.cost}}" data-dtype="Number" />
-          </div>
-        </div>
-        <div class="form-group">
-          <label>{{localize 'OSE.items.Weight'}}</label>
-          <div class="form-fields">
-            <input type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number" />
-          </div>
-        </div>
-      </div>
-      <div class="description">
-        {{editor content=data.description target="data.description" button=true
-        owner=owner editable=editable}}
-      </div>
-    </div>
-  </section>
-</form>
-{{/if}}

--- a/src/templates/items/container-sheet.html
+++ b/src/templates/items/container-sheet.html
@@ -1,4 +1,3 @@
-{{#if (isV10)}}
 <form class="{{cssClass}}" autocomplete="off">
   <header class="sheet-header">
     <img class="profile-img" src="{{img}}" data-edit="img" title="{{name}}" />
@@ -14,59 +13,30 @@
         <div class="form-group">
           <label>{{localize 'OSE.items.Cost'}}</label>
           <div class="form-fields">
-            <input type="text" name="system.cost" value="{{system.cost}}" data-dtype="Number" />
+            <input
+              type="text"
+              name="system.cost"
+              value="{{system.cost}}"
+              data-dtype="Number"
+            />
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'OSE.items.Weight'}}</label>
           <div class="form-fields">
-            <input type="text" name="system.weight" value="{{system.weight}}" data-dtype="Number" />
+            <input
+              type="text"
+              name="system.weight"
+              value="{{system.weight}}"
+              data-dtype="Number"
+            />
           </div>
         </div>
       </div>
       <div class="description weapon-editor">
-        {{editor system.enrichedDescription
-          target="system.description"
-          button=true
-          owner=owner
-          editable=editable
-          async=true
-        }}
+        {{editor system.enrichedDescription target="system.description"
+        button=true owner=owner editable=editable async=true }}
       </div>
     </div>
   </section>
 </form>
-{{else}}
-<form class="{{cssClass}}" autocomplete="off">
-  <header class="sheet-header">
-    <img class="profile-img" src="{{img}}" data-edit="img" title="{{name}}" />
-    <div class="header-col">
-      <h1 class="charname">
-        <input name="name" type="text" value="{{name}}" placeholder="Name" />
-      </h1>
-    </div>
-  </header>
-  <section class="sheet-body">
-    <div class="flexrow">
-      <div class="stats">
-        <div class="form-group">
-          <label>{{localize 'OSE.items.Cost'}}</label>
-          <div class="form-fields">
-            <input type="text" name="data.cost" value="{{data.cost}}" data-dtype="Number" />
-          </div>
-        </div>
-        <div class="form-group">
-          <label>{{localize 'OSE.items.Weight'}}</label>
-          <div class="form-fields">
-            <input type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number" />
-          </div>
-        </div>
-      </div>
-      <div class="description weapon-editor">
-        {{editor content=data.description target="data.description" button=true
-        owner=owner editable=editable}}
-      </div>
-    </div>
-  </section>
-</form>
-{{/if}}

--- a/src/templates/items/item-sheet.html
+++ b/src/templates/items/item-sheet.html
@@ -1,4 +1,3 @@
-{{#if (isV10)}}
 <form class="{{cssClass}}" autocomplete="off">
   <header class="sheet-header">
     <img class="profile-img" src="{{img}}" data-edit="img" title="{{name}}" />
@@ -82,106 +81,9 @@
         </div>
       </div>
       <div class="description weapon-editor">
-        {{editor system.enrichedDescription
-          target="system.details.description"
-          button=true
-          owner=owner
-          editable=editable
-          async=true
-        }}
+        {{editor system.enrichedDescription target="system.details.description"
+        button=true owner=owner editable=editable async=true }}
       </div>
     </div>
   </section>
 </form>
-{{else}}
-<form class="{{cssClass}}" autocomplete="off">
-  <header class="sheet-header">
-    <img class="profile-img" src="{{img}}" data-edit="img" title="{{name}}" />
-    <div class="header-col">
-      <h1 class="charname">
-        <input name="name" type="text" value="{{name}}" placeholder="Name" />
-      </h1>
-      <ol class="tag-list">
-        {{#each data.manualTags as |tag|}}
-        <li class="tag" title="{{tag.title}}" data-tag="{{tag.value}}">
-          <span>{{tag.value}}</span>
-          <a class="tag-delete"><i class="fas fa-times"></i></a>
-        </li>
-        {{/each}}
-      </ol>
-    </div>
-  </header>
-  <section class="sheet-body">
-    <div class="flexrow">
-      <div class="stats">
-        <div class="form-group">
-          <div class="form-fields">
-            <input
-              type="text"
-              data-action="add-tag"
-              title="{{localize 'OSE.items.typeTag'}}"
-              placeholder="{{localize 'OSE.items.enterTag'}}"
-            />
-          </div>
-        </div>
-        <div class="form-group">
-          <label>{{localize 'OSE.items.Quantity'}}</label>
-          <div class="form-fields">
-            <input
-              type="text"
-              name="data.quantity.value"
-              value="{{data.quantity.value}}"
-              data-dtype="Number"
-            />/<input
-              type="text"
-              name="data.quantity.max"
-              value="{{data.quantity.max}}"
-              data-dtype="Number"
-            />
-          </div>
-        </div>
-        <div class="form-group">
-          <label>{{localize 'OSE.items.Treasure'}}</label>
-          <div class="form-fields">
-            <input
-              type="checkbox"
-              name="data.treasure"
-              value="{{data.treasure}}"
-              {{checked
-              data.treasure}}
-              data-dtype="Boolean"
-            />
-          </div>
-        </div>
-        <div class="form-group">
-          <label>{{localize 'OSE.items.Cost'}}</label>
-          <div class="form-fields">
-            <input
-              type="text"
-              name="data.cost"
-              value="{{data.cost}}"
-              data-dtype="Number"
-            />
-          </div>
-        </div>
-        <div class="form-group">
-          <label>{{localize 'OSE.items.Weight'}}</label>
-          <div class="form-fields">
-            <input
-              type="text"
-              name="data.weight"
-              value="{{data.weight}}"
-              data-dtype="Number"
-            />
-          </div>
-        </div>
-      </div>
-      <div class="description weapon-editor">
-        {{editor content=data.details.biography
-        target="data.details.biography" button=true owner=owner
-        editable=editable }}
-      </div>
-    </div>
-  </section>
-</form>
-{{/if}}

--- a/src/templates/items/spell-sheet.html
+++ b/src/templates/items/spell-sheet.html
@@ -1,4 +1,3 @@
-{{#if (isV10)}}
 <form class="{{cssClass}}" autocomplete="off">
   <header class="sheet-header">
     <img class="profile-img" src="{{img}}" data-edit="img" title="{{name}}" />
@@ -14,25 +13,45 @@
         <div class="form-group">
           <label>{{localize 'OSE.spells.Level'}}</label>
           <div class="form-fields">
-            <input type="text" name="system.lvl" value="{{system.lvl}}" data-dtype="Number" />
+            <input
+              type="text"
+              name="system.lvl"
+              value="{{system.lvl}}"
+              data-dtype="Number"
+            />
           </div>
         </div>
         <div class="form-group block-input">
           <label>{{localize 'OSE.spells.Class'}}</label>
           <div class="form-fields">
-            <input type="text" name="system.class" value="{{system.class}}" data-dtype="String" />
+            <input
+              type="text"
+              name="system.class"
+              value="{{system.class}}"
+              data-dtype="String"
+            />
           </div>
         </div>
         <div class="form-group block-input">
           <label>{{localize 'OSE.spells.Duration'}}</label>
           <div class="form-fields">
-            <input type="text" name="system.duration" value="{{system.duration}}" data-dtype="String" />
+            <input
+              type="text"
+              name="system.duration"
+              value="{{system.duration}}"
+              data-dtype="String"
+            />
           </div>
         </div>
         <div class="form-group block-input">
           <label>{{localize 'OSE.spells.Range'}}</label>
           <div class="form-fields">
-            <input type="text" name="system.range" value="{{system.range}}" data-dtype="String" />
+            <input
+              type="text"
+              name="system.range"
+              value="{{system.range}}"
+              data-dtype="String"
+            />
           </div>
         </div>
         <div class="form-group">
@@ -43,92 +62,26 @@
               <option value=""></option>
               {{#each config.saves_short as |save a|}}
               <option value="{{a}}">{{save}}</option>
-              {{/each}}
-              {{/select}}
+              {{/each}} {{/select}}
             </select>
           </div>
         </div>
         <div class="form-group block-input">
           <label>{{localize 'OSE.items.Roll'}}</label>
           <div class="form-fields">
-            <input type="text" name="system.roll" value="{{system.roll}}" data-dtype="String" />
+            <input
+              type="text"
+              name="system.roll"
+              value="{{system.roll}}"
+              data-dtype="String"
+            />
           </div>
         </div>
       </div>
       <div class="description">
-        {{editor system.enrichedDescription
-          target="system.description"
-          button=true
-          owner=owner
-          editable=editable
-          async=true
-        }}
+        {{editor system.enrichedDescription target="system.description"
+        button=true owner=owner editable=editable async=true }}
       </div>
     </div>
   </section>
 </form>
-{{else}}
-<form class="{{cssClass}}" autocomplete="off">
-  <header class="sheet-header">
-    <img class="profile-img" src="{{img}}" data-edit="img" title="{{name}}" />
-    <div class="header-col">
-      <h1 class="charname">
-        <input name="name" type="text" value="{{name}}" placeholder="Name" />
-      </h1>
-    </div>
-  </header>
-  <section class="sheet-body">
-    <div class="flexrow">
-      <div class="stats narrow">
-        <div class="form-group">
-          <label>{{localize 'OSE.spells.Level'}}</label>
-          <div class="form-fields">
-            <input type="text" name="data.lvl" value="{{data.lvl}}" data-dtype="Number" />
-          </div>
-        </div>
-        <div class="form-group block-input">
-          <label>{{localize 'OSE.spells.Class'}}</label>
-          <div class="form-fields">
-            <input type="text" name="data.class" value="{{data.class}}" data-dtype="String" />
-          </div>
-        </div>
-        <div class="form-group block-input">
-          <label>{{localize 'OSE.spells.Duration'}}</label>
-          <div class="form-fields">
-            <input type="text" name="data.duration" value="{{data.duration}}" data-dtype="String" />
-          </div>
-        </div>
-        <div class="form-group block-input">
-          <label>{{localize 'OSE.spells.Range'}}</label>
-          <div class="form-fields">
-            <input type="text" name="data.range" value="{{data.range}}" data-dtype="String" />
-          </div>
-        </div>
-        <div class="form-group">
-          <label>{{localize 'OSE.spells.Save'}}</label>
-          <div class="form-fields">
-            <select name="data.save">
-              {{#select data.save}}
-              <option value=""></option>
-              {{#each config.saves_short as |save a|}}
-              <option value="{{a}}">{{save}}</option>
-              {{/each}}
-              {{/select}}
-            </select>
-          </div>
-        </div>
-        <div class="form-group block-input">
-          <label>{{localize 'OSE.items.Roll'}}</label>
-          <div class="form-fields">
-            <input type="text" name="data.roll" value="{{data.roll}}" data-dtype="String" />
-          </div>
-        </div>
-      </div>
-      <div class="description">
-        {{editor content=data.description target="data.description" button=true
-        owner=owner editable=editable}}
-      </div>
-    </div>
-  </section>
-</form>
-{{/if}}

--- a/src/templates/items/weapon-sheet.html
+++ b/src/templates/items/weapon-sheet.html
@@ -1,4 +1,3 @@
-{{#if (isV10)}}
 <form class="{{cssClass}}" autocomplete="off">
   <header class="sheet-header">
     <img class="profile-img" src="{{img}}" data-edit="img" title="{{name}}" />
@@ -9,17 +8,29 @@
         </h1>
         <div class="details">
           <div class="form-group">
-            <label title="{{localize 'OSE.items.Cost'}}"><i class="fas
-                fa-circle"></i></label>
+            <label title="{{localize 'OSE.items.Cost'}}"
+              ><i class="fas fa-circle"></i
+            ></label>
             <div class="form-fields">
-              <input type="text" name="system.cost" value="{{system.cost}}" data-dtype="Number" />
+              <input
+                type="text"
+                name="system.cost"
+                value="{{system.cost}}"
+                data-dtype="Number"
+              />
             </div>
           </div>
           <div class="form-group">
-            <label title="{{localize 'OSE.items.Weight'}}"><i class="fas
-                fa-weight-hanging"></i></label>
+            <label title="{{localize 'OSE.items.Weight'}}"
+              ><i class="fas fa-weight-hanging"></i
+            ></label>
             <div class="form-fields">
-              <input type="text" name="system.weight" value="{{system.weight}}" data-dtype="Number" />
+              <input
+                type="text"
+                name="system.weight"
+                value="{{system.weight}}"
+                data-dtype="Number"
+              />
             </div>
           </div>
         </div>
@@ -39,38 +50,76 @@
       <div class="stats">
         <div class="form-group">
           <div class="form-fields">
-            <input type="text" data-action="add-tag" title="{{localize 'OSE.items.typeTag'}}"
-              placeholder="{{localize 'OSE.items.enterTag'}}" />
+            <input
+              type="text"
+              data-action="add-tag"
+              title="{{localize 'OSE.items.typeTag'}}"
+              placeholder="{{localize 'OSE.items.enterTag'}}"
+            />
           </div>
         </div>
         <div class="form-group block-input">
           <label>{{localize 'OSE.items.Damage'}}</label>
           <div class="form-fields">
-            <input type="text" name="system.damage" value="{{system.damage}}" data-dtype="String" />
+            <input
+              type="text"
+              name="system.damage"
+              value="{{system.damage}}"
+              data-dtype="String"
+            />
           </div>
         </div>
         <div class="form-group">
-          <label title="{{localize 'OSE.items.AtkBonus'}}">{{localize
-            'OSE.items.Bonus'}}</label>
+          <label title="{{localize 'OSE.items.AtkBonus'}}"
+            >{{localize 'OSE.items.Bonus'}}</label
+          >
           <div class="form-fields">
-            <input type="text" name="system.bonus" value="{{system.bonus}}" data-dtype="Number" />
+            <input
+              type="text"
+              name="system.bonus"
+              value="{{system.bonus}}"
+              data-dtype="Number"
+            />
           </div>
         </div>
         <div class="form-group attack-type">
-          <a title="{{localize 'OSE.items.Melee'}}" class="melee-toggle {{#if
-            system.melee}}active{{/if}}"><i class="fas fa-fist-raised"></i></a>
-          <a title="{{localize 'OSE.items.Missile'}}" class="missile-toggle
-            {{#if system.missile}}active{{/if}}"><i class="fas fa-bullseye"></i></a>
+          <a
+            title="{{localize 'OSE.items.Melee'}}"
+            class="melee-toggle {{#if
+            system.melee}}active{{/if}}"
+            ><i class="fas fa-fist-raised"></i
+          ></a>
+          <a
+            title="{{localize 'OSE.items.Missile'}}"
+            class="missile-toggle
+            {{#if system.missile}}active{{/if}}"
+            ><i class="fas fa-bullseye"></i
+          ></a>
         </div>
         {{#if system.missile}}
         <div class="form-group block-input">
           <label>{{localize 'OSE.items.Range'}}</label>
           <div class="form-fields range">
-            <input type="text" name="system.range.short" value="{{system.range.short}}" data-dtype="Number" />
+            <input
+              type="text"
+              name="system.range.short"
+              value="{{system.range.short}}"
+              data-dtype="Number"
+            />
             <div class="sep"></div>
-            <input type="text" name="system.range.medium" value="{{system.range.medium}}" data-dtype="Number" />
+            <input
+              type="text"
+              name="system.range.medium"
+              value="{{system.range.medium}}"
+              data-dtype="Number"
+            />
             <div class="sep"></div>
-            <input type="text" name="system.range.long" value="{{system.range.long}}" data-dtype="Number" />
+            <input
+              type="text"
+              name="system.range.long"
+              value="{{system.range.long}}"
+              data-dtype="Number"
+            />
           </div>
         </div>
         {{/if}}
@@ -82,133 +131,27 @@
               <option value=""></option>
               {{#each config.saves_short as |save a|}}
               <option value="{{a}}">{{save}}</option>
-              {{/each}}
-              {{/select}}
+              {{/each}} {{/select}}
             </select>
           </div>
         </div>
         <div class="form-group">
           <label>{{localize 'OSE.items.Slow'}}</label>
           <div class="form-fields">
-            <input type="checkbox" name="system.slow" {{checked system.slow}} data-dtype="Boolean" />
+            <input
+              type="checkbox"
+              name="system.slow"
+              {{checked
+              system.slow}}
+              data-dtype="Boolean"
+            />
           </div>
         </div>
       </div>
       <div class="description weapon-editor">
-        {{editor system.enrichedDescription
-          target="system.description"
-          button=true
-          owner=owner
-          editable=editable
-          async=true
-        }}
+        {{editor system.enrichedDescription target="system.description"
+        button=true owner=owner editable=editable async=true }}
       </div>
     </div>
   </section>
 </form>
-{{else}}
-<form class="{{cssClass}}" autocomplete="off">
-  <header class="sheet-header">
-    <img class="profile-img" src="{{img}}" data-edit="img" title="{{name}}" />
-    <div class="header-col">
-      <div class="flexrow">
-        <h1 class="charname">
-          <input name="name" type="text" value="{{name}}" placeholder="Name" />
-        </h1>
-        <div class="details">
-          <div class="form-group">
-            <label title="{{localize 'OSE.items.Cost'}}"><i class="fas
-                fa-circle"></i></label>
-            <div class="form-fields">
-              <input type="text" name="data.cost" value="{{data.cost}}" data-dtype="Number" />
-            </div>
-          </div>
-          <div class="form-group">
-            <label title="{{localize 'OSE.items.Weight'}}"><i class="fas
-                fa-weight-hanging"></i></label>
-            <div class="form-fields">
-              <input type="text" name="data.weight" value="{{data.weight}}" data-dtype="Number" />
-            </div>
-          </div>
-        </div>
-      </div>
-      <ol class="tag-list">
-        {{#each data.manualTags as |tag|}}
-        <li class="tag" title="{{tag.title}}" data-tag="{{tag.value}}">
-          <span>{{tag.value}}</span>
-          <a class="tag-delete"><i class="fas fa-times"></i></a>
-        </li>
-        {{/each}}
-      </ol>
-    </div>
-  </header>
-  <section class="sheet-body">
-    <div class="flexrow">
-      <div class="stats">
-        <div class="form-group">
-          <div class="form-fields">
-            <input type="text" data-action="add-tag" title="{{localize 'OSE.items.typeTag'}}"
-              placeholder="{{localize 'OSE.items.enterTag'}}" />
-          </div>
-        </div>
-        <div class="form-group block-input">
-          <label>{{localize 'OSE.items.Damage'}}</label>
-          <div class="form-fields">
-            <input type="text" name="data.damage" value="{{data.damage}}" data-dtype="String" />
-          </div>
-        </div>
-        <div class="form-group">
-          <label title="{{localize 'OSE.items.AtkBonus'}}">{{localize
-            'OSE.items.Bonus'}}</label>
-          <div class="form-fields">
-            <input type="text" name="data.bonus" value="{{data.bonus}}" data-dtype="Number" />
-          </div>
-        </div>
-        <div class="form-group attack-type">
-          <a title="{{localize 'OSE.items.Melee'}}" class="melee-toggle {{#if
-            data.melee}}active{{/if}}"><i class="fas fa-fist-raised"></i></a>
-          <a title="{{localize 'OSE.items.Missile'}}" class="missile-toggle
-            {{#if data.missile}}active{{/if}}"><i class="fas fa-bullseye"></i></a>
-        </div>
-        {{#if data.missile}}
-        <div class="form-group block-input">
-          <label>{{localize 'OSE.items.Range'}}</label>
-          <div class="form-fields range">
-            <input type="text" name="data.range.short" value="{{data.range.short}}" data-dtype="Number" />
-            <div class="sep"></div>
-            <input type="text" name="data.range.medium" value="{{data.range.medium}}" data-dtype="Number" />
-            <div class="sep"></div>
-            <input type="text" name="data.range.long" value="{{data.range.long}}" data-dtype="Number" />
-          </div>
-        </div>
-        {{/if}}
-        <div class="form-group">
-          <label>{{localize 'OSE.spells.Save'}}</label>
-          <div class="form-fields">
-            <select name="data.save">
-              {{#select data.save}}
-              <option value=""></option>
-              {{#each config.saves_short as |save a|}}
-              <option value="{{a}}">{{save}}</option>
-              {{/each}}
-              {{/select}}
-            </select>
-          </div>
-        </div>
-        <div class="form-group">
-          <label>{{localize 'OSE.items.Slow'}}</label>
-          <div class="form-fields">
-            <input type="checkbox" name="data.slow" value="{{data.slow}}" {{checked data.slow}} data-dtype="Number" />
-          </div>
-        </div>
-      </div>
-      <div class="description weapon-editor">
-        {{editor content=data.description target="data.description" button=true
-        owner=owner editable=editable}}
-        
-      </div>
-    </div>
-  </section>
-</form>
-
-{{/if}}


### PR DESCRIPTION
Tests: 395/395 passing

* The input delay on tests is now 120ms due to some dev machines not completing tests under the 100ms delay
* V9 compatibility code has been removed due to abandoning support for V9 in releases moving forward
* Some remaining references to the data object on documents have been removed
* Removed some errant console logging that accidentally got committed to the system
* returned the dependency caching to the CI workflow
  I placed the `--ignore-scripts` flag on the `npm ci` command after verifying locally that current dependencies do not have required postinstall scripts for `npm run build` to function properly