### PR TITLE
fix: async restores treasure result text

### DIFF
--- a/src/module/treasure.js
+++ b/src/module/treasure.js
@@ -51,21 +51,20 @@ export const augmentTable = (table, html, data) => {
   });
 };
 
-async function percentageRoll (chance) {
-  const roll = new Roll("1d100");
-  roll.evaluate({ async: true });
-  return roll.total <= chance;
-};
-
-async function drawTreasure(table, data) {
+function drawTreasure(table, data) {
+  const percent = (chance) => {
+    const roll = new Roll("1d100");
+    roll.evaluate({ async: false });
+    return roll.total <= chance;
+  };
   data.treasure = {};
   if (table.getFlag(game.system.id, "treasure")) {
     table.results.forEach((r) => {
-      if (percentageRoll(r.data.weight)) {
-        const text = r.getChatText();
+      if (percent(r.data.weight)) {
+        const text = r.getChatText(r);
         data.treasure[r.id] = {
           img: r.data.img,
-          text: TextEditor.enrichHTML(text, {async:true}),
+          text: TextEditor.enrichHTML(text, {async:false}),
         };
         if (
           r.data.type === CONST.TABLE_RESULT_TYPES.DOCUMENT &&
@@ -79,7 +78,7 @@ async function drawTreasure(table, data) {
   } else {
     const results = table.evaluate({ async: false }).results;
     results.forEach((s) => {
-      const text = TextEditor.enrichHTML(table._getResultChatText(s));
+      const text = TextEditor.enrichHTML(table._getResultChatText(s), {async:false});
       data.treasure[s.id] = { img: s.data.img, text: text };
     });
   }

--- a/src/module/treasure.js
+++ b/src/module/treasure.js
@@ -51,20 +51,21 @@ export const augmentTable = (table, html, data) => {
   });
 };
 
-function drawTreasure(table, data) {
-  const percent = (chance) => {
-    const roll = new Roll("1d100");
-    roll.evaluate({ async: false });
-    return roll.total <= chance;
-  };
+async function percentageRoll (chance) {
+  const roll = new Roll("1d100");
+  roll.evaluate({ async: true });
+  return roll.total <= chance;
+};
+
+async function drawTreasure(table, data) {
   data.treasure = {};
   if (table.getFlag(game.system.id, "treasure")) {
     table.results.forEach((r) => {
-      if (percent(r.data.weight)) {
-        const text = r.getChatText(r);
+      if (percentageRoll(r.data.weight)) {
+        const text = r.getChatText();
         data.treasure[r.id] = {
           img: r.data.img,
-          text: TextEditor.enrichHTML(text),
+          text: TextEditor.enrichHTML(text, {async:true}),
         };
         if (
           r.data.type === CONST.TABLE_RESULT_TYPES.DOCUMENT &&


### PR DESCRIPTION
Fixes #268 

This was a case of the default enriched text behavior switching to async, and we missed this particular usage of it