### PR TITLE
fix: Attack/Initiative modifiers are visible on the sheet.

### DIFF
--- a/src/module/actor/character-sheet.js
+++ b/src/module/actor/character-sheet.js
@@ -53,7 +53,13 @@ export class OseActorSheetCharacter extends OseActorSheet {
     data.abilities = this.actor.system.abilities;
     data.spells = this.actor.system.spells.spellList;
     data.slots = this.actor.system.spellSlots;
-
+    
+    // These values are getters that aren't getting
+    // cloned when `this.actor.system` is cloned
+    data.system.meleeMod = this.actor.system.meleeMod;
+    data.system.rangedMod = this.actor.system.rangedMod;
+    data.system.init = this.actor.system.init;
+    
     // Sort by sort order (see ActorSheet)
     [
       ...Object.values(data.owned),


### PR DESCRIPTION
## Intent
This changeset fixes the disappearance of attack and initiative modifiers. It also gives us a lesson for using getters on the data models: we need to re-add them to the sheet context, since the way Foundry clones `actor.system` doesn't clone getters.

Fixes #271