### PR TITLE
fix: don't reroll on round 1 if already rolled

### DIFF
--- a/src/module/combat.js
+++ b/src/module/combat.js
@@ -73,6 +73,10 @@ export class OseCombat {
     let combatants = combat?.combatants;
     for (let i = 0; i < combatants.size; i++) {
       let c = combatants.contents[i];
+      //check if actor initiative has already been set for this round
+      if (c?.initiative) {
+        continue;
+      }
       // This comes from foundry.js, had to remove the update turns thing
       // Roll initiative
       const cf = await c._getInitiativeFormula(c);


### PR DESCRIPTION
fixes #200 

To test, change system combat settings to "Individual Initiative" and "Reset Each Round"
Roll initiative for some characters, and then start the combat. It should allow each character's individually-rolled initiative to stay

Please review the behavior to see if you have any ideas to improve the overall experience. I think it's still not perfect