### PR TITLE
fix(temporary): removed caching from the build ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
       # Get dev dependencies for the package, including Gulp and Rollup
       - name: Install dev dependencies
-        run: npm ci --cache .npm --prefer-offline --ignore-scripts
+        run: npm ci #--cache .npm --prefer-offline --ignore-scripts
 
       # Create a build using Gulp build script
       - name: Run Gulp build script


### PR DESCRIPTION
Unfortunately a fix I had implemented in October for build caching was seemingly never tested (it only ever rears its head in GitHub Actions).

The original fix `--ignore-scripts` still doesn't prevent husky from throwing an error when caching is enabled. We don't even use husky, it's a dependency for the type definitions.

We don't particularly need to cache our dependencies, it's just a best practice. I'd like to return to this when we're not late for a planned release