### PR TITLE
fix: AC/AAC display fix + party overview fix

### DIFF
--- a/src/module/actor/character-sheet.js
+++ b/src/module/actor/character-sheet.js
@@ -56,6 +56,7 @@ export class OseActorSheetCharacter extends OseActorSheet {
     
     // These values are getters that aren't getting
     // cloned when `this.actor.system` is cloned
+    data.system.usesAscendingAC = this.actor.system.usesAscendingAC;
     data.system.meleeMod = this.actor.system.meleeMod;
     data.system.rangedMod = this.actor.system.rangedMod;
     data.system.init = this.actor.system.init;

--- a/src/module/party/party-sheet.js
+++ b/src/module/party/party-sheet.js
@@ -115,7 +115,7 @@ export class OsePartySheet extends FormApplication {
   }
 
   _recursiveAddFolder(folder) {
-    folder.content.forEach((actor) => this._addActorToParty(actor));
+    folder.contents.forEach((actor) => this._addActorToParty(actor));
     folder.children.forEach((folder) => this._recursiveAddFolder(folder));
   }
 

--- a/src/module/party/party.js
+++ b/src/module/party/party.js
@@ -10,8 +10,8 @@ export class OseParty {
     const characters = game.actors.filter(
       (act) =>
         act.type === "character" &&
-        act.flags[OSE.systemName] &&
-        act.flags[OSE.systemName].party === true
+        act.flags[game.system.id] &&
+        act.flags[game.system.id].party === true
     );
     return characters;
   }


### PR DESCRIPTION
## Intent

This changeset fixes two regressions surfaced after the release of 1.7.1:
1. Sheets for Actors of type Character did not render the correct AC scheme
2. Actors of type Character could not be added to the party overview.

Fixes #285
Fixes #288