### PR TITLE
fix: Additional v1.7.x fixes

### DIFF
--- a/src/module/actor/actor-sheet.js
+++ b/src/module/actor/actor-sheet.js
@@ -371,7 +371,7 @@ export class OseActorSheet extends ActorSheet {
   _createItem(event) {
     event.preventDefault();
     const header = event.currentTarget;
-    const type = header.dataset.type;
+    const { treasure, type } = header.dataset;
     const createItem = (type, name) => ({
       name: name ? name : `New ${type.capitalize()}`,
       type: type,
@@ -384,8 +384,11 @@ export class OseActorSheet extends ActorSheet {
         const itemData = createItem(dialogInput.type, dialogInput.name);
         this.actor.createEmbeddedDocuments("Item", [itemData], {});
       });
-    } else
-      return this.actor.createEmbeddedDocuments("Item", [createItem(type)], {});
+    } else {
+      const itemData = createItem(type);
+      if (treasure) itemData.system = { treasure: true }
+      return this.actor.createEmbeddedDocuments("Item", [itemData], {});
+    }
   }
 
   async _updateItemQuantity(event) {

--- a/src/module/dialog/character-creation.js
+++ b/src/module/dialog/character-creation.js
@@ -28,7 +28,7 @@ export class OseCharacterCreator extends FormApplication {
    * @return {Object}
    */
   getData() {
-    let data = foundry.utils.deepClone(this.object.data);
+    let data = foundry.utils.deepClone(this.object);
     data.user = game.user;
     data.config = CONFIG.OSE;
     this.counters = {
@@ -178,7 +178,7 @@ export class OseCharacterCreator extends FormApplication {
     event,
     { updateData = null, preventClose = false, preventRender = false } = {}
   ) {
-    updateData = { ...updateData, data: { scores: this.scores } };
+    updateData = { ...updateData, system: { scores: this.scores } };
     super._onSubmit(event, {
       updateData: updateData,
       preventClose: preventClose,

--- a/src/module/item/data-model-item.js
+++ b/src/module/item/data-model-item.js
@@ -3,9 +3,7 @@ export default class OseDataModelItem extends foundry.abstract.DataModel {
 		const { SchemaField, StringField, NumberField, BooleanField, ArrayField, ObjectField } = foundry.data.fields;
 		return {
 			treasure: new BooleanField(),
-			details: new ObjectField({
-				description: new StringField(),
-			}),
+			description: new StringField(),
 			tags: new ArrayField(new ObjectField()),
 			cost: new NumberField({ min: 0, initial: 0 }),
 			containerId: new StringField(),
@@ -17,6 +15,11 @@ export default class OseDataModelItem extends foundry.abstract.DataModel {
 		};
 	}
 
+	static migrateData(source) {
+		if (source.details?.description && !source.description)
+			source.description = source.details.description;
+		return source;
+	}
 	get manualTags() {
 		if (!this.tags) return null;
 

--- a/src/module/item/item-sheet.js
+++ b/src/module/item/item-sheet.js
@@ -52,7 +52,7 @@ export class OseItemSheet extends ItemSheet {
     data.config = CONFIG.OSE;
     data.enriched = {
       description: await TextEditor.enrichHTML(
-        this.item.system?.description || this.item.system?.details?.description || "",
+        this.item.system?.description || "",
         {async: true}
       )
     }

--- a/src/templates/items/armor-sheet.html
+++ b/src/templates/items/armor-sheet.html
@@ -87,7 +87,7 @@
         </div>
       </div>
       <div class="description">
-        {{editor system.enrichedDescription target="system.description"
+        {{editor enriched.description target="system.description"
         button=true owner=owner editable=editable async=true}}
       </div>
     </div>

--- a/src/templates/items/item-sheet.html
+++ b/src/templates/items/item-sheet.html
@@ -82,7 +82,7 @@
       </div>
       <div class="description weapon-editor">
         {{editor enriched.description
-          target="system.details.description"
+          target="system.description"
           button=true
           owner=owner
           editable=editable


### PR DESCRIPTION
## Intent

This changeset fixes some additional bugs found by users, namely:
* The character generator once again generates stats
* Treasure items created from the character sheet once again go into the correct heading
* Items of `item` type should once again display their descriptions

Note: I'm not 100% sure how to test the item description fix, but I'm happy to take suggestions!