### PR TITLE
[enhancement] Added option to revert Ctrl/Meta behavior

### DIFF
--- a/src/e2e/actor/character.e2e.test.js
+++ b/src/e2e/actor/character.e2e.test.js
@@ -5,8 +5,6 @@ export const options = {
   displayName: 'The Character Sheet'
 };
 
-// TODO: Write Monster roll tests
-
 /**
  * If there are dialogs, close them.
  * @returns {Promise} the promise from closing dialogs

--- a/src/e2e/actor/character.e2e.test.js
+++ b/src/e2e/actor/character.e2e.test.js
@@ -5,6 +5,8 @@ export const options = {
   displayName: 'The Character Sheet'
 };
 
+// TODO: Write Monster roll tests
+
 /**
  * If there are dialogs, close them.
  * @returns {Promise} the promise from closing dialogs

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -181,6 +181,8 @@
   "OSE.Setting.applyDamageOptionHint": "Auf welche(n) Token bei einem Angriffswurf Schaden angewendet werden soll",
   "OSE.Setting.damageSelected": "Ausgewählt",
   "OSE.Setting.damageTarget": "Ziel",
+  "OSE.Setting.InvertedCtrlBehavior": "Roll umkehren Ctrl/Meta-Taste",
+  "OSE.Setting.InvertedCtrlBehaviorHint": "Kehrt das Verhalten beim Halten von Ctrl/Meta beim Klicken auf eine Rolle um.",
   "OSE.items.Equip": "Ausrüsten",
   "OSE.items.Unequip": "Unausgerüsten",
   "OSE.items.Misc": "Sonstiges",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -200,6 +200,8 @@
   "OSE.Setting.applyDamageOptionHint": "Which token(s) to apply damage to on an attack roll",
   "OSE.Setting.damageSelected": "Selected",
   "OSE.Setting.damageTarget": "Target",
+  "OSE.Setting.InvertedCtrlBehavior": "Invert Roll Ctrl/Meta-key",
+  "OSE.Setting.InvertedCtrlBehaviorHint": "Reverses behavior for holding Ctrl/Meta when clicking on a roll.",
 
   "OSE.items.Equip": "Equip",
   "OSE.items.Unequip": "Unequip",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -181,6 +181,8 @@
   "OSE.Setting.applyDamageOptionHint": "El(los) token(s) a los que se le aplicará el daño de una tirada de ataque",
   "OSE.Setting.damageSelected": "Seleccionado",
   "OSE.Setting.damageTarget": "Objetivo",
+  "OSE.Setting.InvertedCtrlBehavior": "Invertir rollo Ctrl/Meta-tecla",
+  "OSE.Setting.InvertedCtrlBehaviorHint": "Invierte el comportamiento para mantener presionadas las teclas Ctrl/Meta al hacer clic en un rollo.",
   "OSE.items.Equip": "Equipar",
   "OSE.items.Unequip": "Desequipar",
   "OSE.items.Misc": "Misc",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -191,6 +191,8 @@
   "OSE.Setting.Languages": "Langues",
   "OSE.Setting.LanguagesHint": "Entrez une liste des Langues de l'univers séparée par des virgules",
   "OSE.Setting.EnableInventory": "Afficher l'inventaire",
+  "OSE.Setting.InvertedCtrlBehavior": "Inverser le rouleau Ctrl/Méta-clé",
+  "OSE.Setting.InvertedCtrlBehaviorHint": "Inverse le comportement consistant à maintenir Ctrl/Meta enfoncé lorsque vous cliquez sur un rouleau.",
 
   "OSE.items.Equip": "Equiper",
   "OSE.items.Unequip": "Déséquiper",

--- a/src/lang/it.json
+++ b/src/lang/it.json
@@ -180,6 +180,8 @@
   "OSE.Setting.applyDamageOptionHint": "Token ai quali applicare i danni in arrivo",
   "OSE.Setting.damageSelected": "Token Selezionato",
   "OSE.Setting.damageTarget": "Token Bersaglio",
+  "OSE.Setting.InvertedCtrlBehavior": "Inverti Roll Ctrl/Meta-tasto",
+  "OSE.Setting.InvertedCtrlBehaviorHint": "Inverte il comportamento tenendo premuto Ctrl/Meta quando si fa clic su un rotolo.",
   "OSE.items.Equip": "Indossa o Impugna",
   "OSE.items.Unequip": "Togli o Riponi",
   "OSE.items.Misc": "Altro",

--- a/src/lang/pt-BR.json
+++ b/src/lang/pt-BR.json
@@ -180,6 +180,8 @@
   "OSE.Setting.applyDamageOptionHint": "Em quais tokens aplicar dano em uma rolagem de ataque",
   "OSE.Setting.damageSelected": "Selecionado",
   "OSE.Setting.damageTarget": "Alvo",
+  "OSE.Setting.InvertedCtrlBehavior": "Inverter Rolo Ctrl/Meta-tecla",
+  "OSE.Setting.InvertedCtrlBehaviorHint": "Inverte o comportamento de manter pressionada a tecla Ctrl/Meta ao clicar em um rolo.",
   "OSE.items.Equip": "Equipar",
   "OSE.items.Unequip": "Desequipar",
   "OSE.items.Misc": "Diverso",

--- a/src/module/actor/actor-sheet.js
+++ b/src/module/actor/actor-sheet.js
@@ -1,5 +1,6 @@
 import { OseEntityTweaks } from "../dialog/entity-tweaks";
 import { OSE } from "../config";
+import { skipRollDialogCheck } from "../behaviourHelpers";
 
 export class OseActorSheet extends ActorSheet {
   constructor(...args) {
@@ -167,11 +168,11 @@ export class OseActorSheet extends ActorSheet {
           'system.counter.value': itemData.counter.value - 1
         });
       }
-      item.rollWeapon({ skipDialog: event.ctrlKey || event.metaKey });
+      item.rollWeapon({ skipDialog: skipRollDialogCheck(event) });
     } else if (item.type == "spell") {
-      item.spendSpell({ skipDialog: event.ctrlKey || event.metaKey });
+      item.spendSpell({ skipDialog: skipRollDialogCheck(event)});
     } else {
-      item.rollFormula({ skipDialog: event.ctrlKey || event.metaKey });
+      item.rollFormula({ skipDialog: skipRollDialogCheck(event) });
     }
   }
 
@@ -188,7 +189,7 @@ export class OseActorSheet extends ActorSheet {
     let attack = element.parentElement.parentElement.dataset.attack;
     actorObject.targetAttack({ roll: {} }, attack, {
       type: attack,
-      skipDialog: event.ctrlKey || event.metaKey,
+      skipDialog: skipRollDialogCheck(event),
     });
   }
 

--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -134,7 +134,13 @@ export class OseActor extends Actor {
       details: game.i18n.format("OSE.roll.details.save", { save: label }),
     };
 
-    let skip = options?.event?.ctrlKey || options.fastForward;
+    const invertedCtrlBehavior = game.settings.get(game.system.id, "invertedCtrlBehavior");
+    let skip = 
+      options.fastForward ||
+      invertedCtrlBehavior ? 
+        !(options.event && (options.event.ctrlKey || options.event.metaKey))
+        :
+        (options.event && (options.event.ctrlKey || options.event.metaKey));
 
     const rollMethod =
       actorType === "character" ? OseDice.RollSave : OseDice.Roll;
@@ -267,7 +273,13 @@ export class OseActor extends Actor {
       }),
     };
 
-    let skip = options?.event?.ctrlKey || options.fastForward;
+    const invertedCtrlBehavior = game.settings.get(game.system.id, "invertedCtrlBehavior");
+    let skip = 
+      options.fastForward ||
+      invertedCtrlBehavior ? 
+        !(options.event && (options.event.ctrlKey || options.event.metaKey))
+        :
+        (options.event && (options.event.ctrlKey || options.event.metaKey));
 
     // Roll and return
     return OseDice.Roll({
@@ -368,9 +380,13 @@ export class OseActor extends Actor {
       }),
     };
 
-    let skip =
+    const invertedCtrlBehavior = game.settings.get(game.system.id, "invertedCtrlBehavior");
+    let skip = 
       options.fastForward ||
-      (options.event && (options.event.ctrlKey || options.event.metaKey));
+      invertedCtrlBehavior ? 
+        !(options.event && (options.event.ctrlKey || options.event.metaKey))
+        :
+        (options.event && (options.event.ctrlKey || options.event.metaKey));
 
     // Roll and return
     return OseDice.Roll({

--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -33,6 +33,15 @@ export class OseActor extends Actor {
     return super.createEmbeddedDocuments(embeddedName, data, context);
   }
 
+  skipRollDialogCheck(options) {
+    const invertedCtrlBehavior = game.settings.get(game.system.id, "invertedCtrlBehavior");
+    return options.fastForward ||
+      invertedCtrlBehavior ? 
+        !(options.event && (options.event.ctrlKey || options.event.metaKey))
+        :
+        (options.event && (options.event.ctrlKey || options.event.metaKey));
+  }
+
   /* -------------------------------------------- */
   /*  Socket Listeners and Handlers
     /* -------------------------------------------- */
@@ -134,14 +143,6 @@ export class OseActor extends Actor {
       details: game.i18n.format("OSE.roll.details.save", { save: label }),
     };
 
-    const invertedCtrlBehavior = game.settings.get(game.system.id, "invertedCtrlBehavior");
-    let skip = 
-      options.fastForward ||
-      invertedCtrlBehavior ? 
-        !(options.event && (options.event.ctrlKey || options.event.metaKey))
-        :
-        (options.event && (options.event.ctrlKey || options.event.metaKey));
-
     const rollMethod =
       actorType === "character" ? OseDice.RollSave : OseDice.Roll;
 
@@ -150,7 +151,7 @@ export class OseActor extends Actor {
       event: options.event,
       parts: rollParts,
       data: data,
-      skipDialog: skip,
+      skipDialog: this.skipRollDialogCheck(options),
       speaker: ChatMessage.getSpeaker({ actor: this }),
       flavor: game.i18n.format("OSE.roll.save", { save: label }),
       title: game.i18n.format("OSE.roll.save", { save: label }),
@@ -236,15 +237,12 @@ export class OseActor extends Actor {
       },
     };
 
-    let skip =
-      options.event && (options.event.ctrlKey || options.event.metaKey);
-
     // Roll and return
     return OseDice.Roll({
       event: options.event,
       parts: rollParts,
       data: data,
-      skipDialog: skip,
+      skipDialog: this.skipRollDialogCheck(options),
       speaker: ChatMessage.getSpeaker({ actor: this }),
       flavor: game.i18n.localize("OSE.reaction.check"),
       title: game.i18n.localize("OSE.reaction.check"),
@@ -273,20 +271,12 @@ export class OseActor extends Actor {
       }),
     };
 
-    const invertedCtrlBehavior = game.settings.get(game.system.id, "invertedCtrlBehavior");
-    let skip = 
-      options.fastForward ||
-      invertedCtrlBehavior ? 
-        !(options.event && (options.event.ctrlKey || options.event.metaKey))
-        :
-        (options.event && (options.event.ctrlKey || options.event.metaKey));
-
     // Roll and return
     return OseDice.Roll({
       event: options.event,
       parts: rollParts,
       data: data,
-      skipDialog: skip,
+      skipDialog: this.skipRollDialogCheck(options),
       speaker: ChatMessage.getSpeaker({ actor: this }),
       flavor: game.i18n.format("OSE.roll.attribute", { attribute: label }),
       title: game.i18n.format("OSE.roll.attribute", { attribute: label }),
@@ -380,20 +370,12 @@ export class OseActor extends Actor {
       }),
     };
 
-    const invertedCtrlBehavior = game.settings.get(game.system.id, "invertedCtrlBehavior");
-    let skip = 
-      options.fastForward ||
-      invertedCtrlBehavior ? 
-        !(options.event && (options.event.ctrlKey || options.event.metaKey))
-        :
-        (options.event && (options.event.ctrlKey || options.event.metaKey));
-
     // Roll and return
     return OseDice.Roll({
       event: options.event,
       parts: rollParts,
       data: data,
-      skipDialog: skip,
+      skipDialog: this.skipRollDialogCheck(options),
       speaker: ChatMessage.getSpeaker({ actor: this }),
       flavor: game.i18n.format("OSE.roll.exploration", { exploration: label }),
       title: game.i18n.format("OSE.roll.exploration", { exploration: label }),

--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -1,3 +1,4 @@
+import { skipRollDialogCheck } from "../behaviourHelpers";
 import { OseDice } from "../dice";
 import { OseItem } from "../item/entity";
 
@@ -31,15 +32,6 @@ export class OseActor extends Actor {
       }
     });
     return super.createEmbeddedDocuments(embeddedName, data, context);
-  }
-
-  skipRollDialogCheck(options) {
-    const invertedCtrlBehavior = game.settings.get(game.system.id, "invertedCtrlBehavior");
-    return options.fastForward ||
-      invertedCtrlBehavior ? 
-        !(options.event && (options.event.ctrlKey || options.event.metaKey))
-        :
-        (options.event && (options.event.ctrlKey || options.event.metaKey));
   }
 
   /* -------------------------------------------- */
@@ -151,7 +143,7 @@ export class OseActor extends Actor {
       event: options.event,
       parts: rollParts,
       data: data,
-      skipDialog: this.skipRollDialogCheck(options),
+      skipDialog: (options.fastForward || skipRollDialogCheck(options.event)),
       speaker: ChatMessage.getSpeaker({ actor: this }),
       flavor: game.i18n.format("OSE.roll.save", { save: label }),
       title: game.i18n.format("OSE.roll.save", { save: label }),
@@ -242,7 +234,7 @@ export class OseActor extends Actor {
       event: options.event,
       parts: rollParts,
       data: data,
-      skipDialog: this.skipRollDialogCheck(options),
+      skipDialog: (options.fastForward || skipRollDialogCheck(options.event)),
       speaker: ChatMessage.getSpeaker({ actor: this }),
       flavor: game.i18n.localize("OSE.reaction.check"),
       title: game.i18n.localize("OSE.reaction.check"),
@@ -276,7 +268,7 @@ export class OseActor extends Actor {
       event: options.event,
       parts: rollParts,
       data: data,
-      skipDialog: this.skipRollDialogCheck(options),
+      skipDialog: (options.fastForward || skipRollDialogCheck(options.event)),
       speaker: ChatMessage.getSpeaker({ actor: this }),
       flavor: game.i18n.format("OSE.roll.attribute", { attribute: label }),
       title: game.i18n.format("OSE.roll.attribute", { attribute: label }),
@@ -375,7 +367,7 @@ export class OseActor extends Actor {
       event: options.event,
       parts: rollParts,
       data: data,
-      skipDialog: this.skipRollDialogCheck(options),
+      skipDialog: (options.fastForward || skipRollDialogCheck(options.event)),
       speaker: ChatMessage.getSpeaker({ actor: this }),
       flavor: game.i18n.format("OSE.roll.exploration", { exploration: label }),
       title: game.i18n.format("OSE.roll.exploration", { exploration: label }),

--- a/src/module/behaviourHelpers.js
+++ b/src/module/behaviourHelpers.js
@@ -1,8 +1,5 @@
 export const skipRollDialogCheck = (event) => {
     const invertedCtrlBehavior = game.settings.get(game.system.id, "invertedCtrlBehavior");
-
-    console.log('Helper triggered.')
-
     return invertedCtrlBehavior ? 
         !(event && (event.ctrlKey || event.metaKey))
         :

--- a/src/module/behaviourHelpers.js
+++ b/src/module/behaviourHelpers.js
@@ -1,0 +1,10 @@
+export const skipRollDialogCheck = (event) => {
+    const invertedCtrlBehavior = game.settings.get(game.system.id, "invertedCtrlBehavior");
+
+    console.log('Helper triggered.')
+
+    return invertedCtrlBehavior ? 
+        !(event && (event.ctrlKey || event.metaKey))
+        :
+        (event && (event.ctrlKey || event.metaKey));
+}

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -86,6 +86,14 @@ export const registerSettings = function () {
       targeted: "OSE.Setting.damageTarget",
     },
   });
+  game.settings.register(game.system.id, "invertedCtrlBehavior", {
+    name: game.i18n.localize("OSE.Setting.InvertedCtrlBehavior"),
+    hint: game.i18n.localize("OSE.Setting.InvertedCtrlBehaviorHint"),
+    default: false,
+    scope: "world",
+    type: Boolean,
+    config: true,
+  })
 };
 
 declare global {


### PR DESCRIPTION
resolves vttred/ose#124

Fixed the Mac-issues with Meta key for rolling, and added an option to reverse the behavior of clicking on a roll with ctrl/meta held down.