### PR TITLE
fix: Macro creation

### DIFF
--- a/src/e2e/index.ts
+++ b/src/e2e/index.ts
@@ -1,7 +1,7 @@
 import macroTests, {
   key as macroKey,
   options as macroOptions
-} from '../module/__tests__/macro.test';
+} from '../module/__tests__/macros.test';
 
 import characterItemMacroTests, {
   key as characterItemMacroKey,

--- a/src/e2e/index.ts
+++ b/src/e2e/index.ts
@@ -1,3 +1,8 @@
+import macroTests, {
+  key as macroKey,
+  options as macroOptions
+} from '../module/__tests__/macro.test';
+
 import characterItemMacroTests, {
   key as characterItemMacroKey,
   options as characterItemMacroOptions
@@ -51,6 +56,7 @@ type Quench = {
 }
 
 Hooks.on('quenchReady', async (quench: Quench) => {
+  quench.registerBatch(macroKey, macroTests, macroOptions);
   quench.registerBatch(characterItemMacroKey, characterItemMacroTests, characterItemMacroOptions);
   quench.registerBatch(characterKey, characterTests, characterOptions);
   // Character data model classes

--- a/src/module/__tests__/macro.test.js
+++ b/src/module/__tests__/macro.test.js
@@ -1,0 +1,38 @@
+import { createOseMacro } from '../../module/macros';
+
+export const key = 'ose.macro';
+export const options = { displayName: 'Macro' };
+
+const createMockMacro = () =>
+    Macro.create({
+        name: `Mock Macro ${foundry.utils.randomID()}`,
+        type: "script",
+        command: "console.log('Testing Macro');",
+    })
+
+const cleanUpMacros = () => {
+    const mockMacros = game.macros.filter(o => o.name.indexOf('Mock Macro') >= 0);
+    mockMacros.forEach(o => o.delete())
+}
+
+export default ({ describe, it, expect, assert, ...context }) => {
+    afterEach( () => cleanUpMacros() )
+
+    describe('Macro', () => {
+        it('Can create macro', async () => {
+            const macro = await createMockMacro();
+            expect(game.macros.contents.find(m => m.uuid === macro.uuid)).not.equal(undefined);
+        })
+        it('Can drag macro to hotbar', async () => {
+            const macro = await createMockMacro();
+            // Mock data that is used when drag'n'dropping
+            const data = { type: "Macro", uuid: macro.uuid }
+            const macroSlot = 9;
+
+            await createOseMacro(data, macroSlot);
+            const hotbar = game.user.getHotbarMacros(1);
+
+            expect(hotbar[macroSlot - 1].macro).equal(macro);
+        })
+    })
+};

--- a/src/module/__tests__/macros.test.js
+++ b/src/module/__tests__/macros.test.js
@@ -1,4 +1,4 @@
-import { createOseMacro } from '../../module/macros';
+import { createOseMacro } from '../macros';
 
 export const key = 'ose.macro';
 export const options = { displayName: 'Macro' };

--- a/src/module/macros.js
+++ b/src/module/macros.js
@@ -10,6 +10,9 @@
  * @returns {Promise}
  */
 export async function createOseMacro(data, slot) {
+  if (data.type === "Macro") {
+    return game.user.assignHotbarMacro(await fromUuid(data.uuid), slot);
+  }
   if (data.type !== "Item") return;
   if ( data.uuid.indexOf("Item.") <= 0 )
     return ui.notifications.warn(
@@ -22,7 +25,7 @@ export async function createOseMacro(data, slot) {
   let macro = game.macros.contents.find(
     (m) => m.name === item.name && m.command === command
   );
-  if (!macro) {
+  if (!macro || macro.ownership[game.userId] === undefined ) {
     macro = await Macro.create({
       name: item.name,
       type: "script",


### PR DESCRIPTION
resolves #311 

This fixes an issue that was reported on Discord, where the user was unable to drag existing macros to the hotbar.

I've added tests for both creating macros, and dragging an existing macro to the hotbar.

This also includes the fixes that was merged into 1.8.x in #314 