### PR TITLE
fix: encumbrance data models now reflect RAW

### DIFF
--- a/src/module/actor/data-model-classes/__tests__/data-model-character-encumbrance.test.ts
+++ b/src/module/actor/data-model-classes/__tests__/data-model-character-encumbrance.test.ts
@@ -117,10 +117,10 @@ export default ({
         expect(enc.value).to.equal(0);
       })
       describe('As fully encumbered flag', () => {
-        it('Encumbered at full load', () => {
+        it('Encumbered over full load (1600.1)', () => {
           const enc = new EncumbranceBasic(
             1600,
-            [createMockItem('item', 1600, 1, { treasure: true })]
+            [createMockItem('item', 1600.1, 1, { treasure: true })]
           );
           expect(enc.encumbered).to.be.true;
         })
@@ -129,10 +129,10 @@ export default ({
             const enc = new EncumbranceBasic(
               1600,
               [
-                createMockItem('weapon', 1600, 1),
-                createMockItem('armor', 1600, 1),
-                createMockItem('container', 1600, 1),
-                createMockItem('item', 1600, 1)
+                createMockItem('weapon', 1600.1, 1),
+                createMockItem('armor', 1600.1, 1),
+                createMockItem('container', 1600.1, 1),
+                createMockItem('item', 1600.1, 1)
               ]
             );
             expect(enc.encumbered).to.be.false;
@@ -269,10 +269,10 @@ export default ({
 
       })
       describe('As fully encumbered flag', () => {
-        it('Encumbered at full load', () => {
+        it('Encumbered over full load (1600.1)', () => {
           const enc = new EncumbranceDetailed(
             1600,
-            [createMockItem('item', 1600, 1, { treasure: true })]
+            [createMockItem('item', 1600.1, 1, { treasure: true })]
           );
           expect(enc.encumbered).to.be.true;
         })
@@ -281,7 +281,7 @@ export default ({
             const enc = new EncumbranceDetailed(
               1600,
               [
-                createMockItem('item', 1600, 1)
+                createMockItem('item', 1600.1, 1)
               ]
             );
             expect(enc.encumbered).to.be.false;
@@ -395,15 +395,15 @@ export default ({
 
       })
       describe('As fully encumbered flag', () => {
-        it('Encumbered at full load', () => {
+        it('Encumbered over full load (1600.1)', () => {
           let enc = new EncumbranceComplete(
             1600,
-            [createMockItem('item', 1600, 1, { treasure: true })]
+            [createMockItem('item', 1600.1, 1, { treasure: true })]
           );
           expect(enc.encumbered).to.be.true;
           enc = new EncumbranceComplete(
             1600,
-            [createMockItem('item', 1600, 1, { treasure: false })]
+            [createMockItem('item', 1600.1, 1, { treasure: false })]
           );
           expect(enc.encumbered).to.be.true;
         })

--- a/src/module/actor/data-model-classes/__tests__/data-model-character-move.test.ts
+++ b/src/module/actor/data-model-classes/__tests__/data-model-character-move.test.ts
@@ -98,7 +98,7 @@ export default ({
     })
   })
   describe('Correctly calculates from Detailed Encumbrance', () => {
-    it('At unencumbered', () => {
+    it('At 0% encumbered (100% moverate)', () => {
       const expectedBase = OseDataModelCharacterMove.baseMoveRate;
       const expectedEncounter = expectedBase / 3;
       const expectedOverland = expectedBase / 5;
@@ -119,8 +119,8 @@ export default ({
       expect(move.encounter).to.equal(expectedEncounter);
       expect(move.overland).to.equal(expectedOverland);
     })
-    it('At 12.5% encumbered', () => {
-      const expectedBase = OseDataModelCharacterMove.baseMoveRate * .75;
+    it('At 12.5% encumbered (100% moverate)', () => {
+      const expectedBase = OseDataModelCharacterMove.baseMoveRate;
       const expectedEncounter = expectedBase / 3;
       const expectedOverland = expectedBase / 5;
       
@@ -133,8 +133,8 @@ export default ({
       expect(move.encounter).to.equal(expectedEncounter)
       expect(move.overland).to.equal(expectedOverland)
     })
-    it('At 25% encumbered', () => {
-      const expectedBase = OseDataModelCharacterMove.baseMoveRate * .5;
+    it('At 25% encumbered (100% moverate)', () => {
+      const expectedBase = OseDataModelCharacterMove.baseMoveRate;
       const expectedEncounter = expectedBase / 3;
       const expectedOverland = expectedBase / 5;
       
@@ -147,24 +147,80 @@ export default ({
       expect(move.encounter).to.equal(expectedEncounter)
       expect(move.overland).to.equal(expectedOverland)
     })
-    it('At 50% encumbered', () => {
+    it('At 25.1% encumbered (75% moverate)', () => {
+      const expectedBase = OseDataModelCharacterMove.baseMoveRate * .75;
+      const expectedEncounter = expectedBase / 3;
+      const expectedOverland = expectedBase / 5;
+      
+      let enc = new EncumbranceDetailed(undefined, [
+        createMockItem('item', OseDataModelCharacterEncumbrance.baseEncumbranceCap * .251, 1, {treasure: true}),
+      ]);
+      let move = new OseDataModelCharacterMove(enc);
+
+      expect(move.base).to.equal(expectedBase);
+      expect(move.encounter).to.equal(expectedEncounter)
+      expect(move.overland).to.equal(expectedOverland)
+    })
+    it('At 37.5% encumbered (75% moverate)', () => {
+      const expectedBase = OseDataModelCharacterMove.baseMoveRate * .75;
+      const expectedEncounter = expectedBase / 3;
+      const expectedOverland = expectedBase / 5;
+      
+      let enc = new EncumbranceDetailed(undefined, [
+        createMockItem('item', OseDataModelCharacterEncumbrance.baseEncumbranceCap * .375, 1, {treasure: true}),
+      ]);
+      let move = new OseDataModelCharacterMove(enc);
+
+      expect(move.base).to.equal(expectedBase);
+      expect(move.encounter).to.equal(expectedEncounter)
+      expect(move.overland).to.equal(expectedOverland)
+    })
+    it('At 37.51% encumbered (50% moverate)', () => {
+      const expectedBase = OseDataModelCharacterMove.baseMoveRate * .50;
+      const expectedEncounter = expectedBase / 3;
+      const expectedOverland = expectedBase / 5;
+      
+      let enc = new EncumbranceDetailed(undefined, [
+        createMockItem('item', OseDataModelCharacterEncumbrance.baseEncumbranceCap * .3751, 1, {treasure: true}),
+      ]);
+      let move = new OseDataModelCharacterMove(enc);
+
+      expect(move.base).to.equal(expectedBase);
+      expect(move.encounter).to.equal(expectedEncounter)
+      expect(move.overland).to.equal(expectedOverland)
+    })
+    it('At 50% encumbered (50% moverate)', () => {
+      const expectedBase = OseDataModelCharacterMove.baseMoveRate * .50;
+      const expectedEncounter = expectedBase / 3;
+      const expectedOverland = expectedBase / 5;
+      
+      let enc = new EncumbranceDetailed(undefined, [
+        createMockItem('item', OseDataModelCharacterEncumbrance.baseEncumbranceCap * .5, 1, {treasure: true}),
+      ]);
+      let move = new OseDataModelCharacterMove(enc);
+
+      expect(move.base).to.equal(expectedBase);
+      expect(move.encounter).to.equal(expectedEncounter)
+      expect(move.overland).to.equal(expectedOverland)
+    })
+    it('At 50.1% encumbered (25% moverate)', () => {
       const expectedBase = OseDataModelCharacterMove.baseMoveRate * .25;
       const expectedEncounter = expectedBase / 3;
       const expectedOverland = expectedBase / 5;
       
       let enc = new EncumbranceDetailed(undefined, [
-        createMockItem('item', OseDataModelCharacterEncumbrance.baseEncumbranceCap * .75, 1, {treasure: true}),
+        createMockItem('item', OseDataModelCharacterEncumbrance.baseEncumbranceCap * .501, 1, {treasure: true}),
       ]);
       let move = new OseDataModelCharacterMove(enc);
 
+      expect(move.base).to.equal(expectedBase);
       expect(move.encounter).to.equal(expectedEncounter)
       expect(move.overland).to.equal(expectedOverland)
-      expect(move.base).to.equal(OseDataModelCharacterMove.baseMoveRate * .25);
     })
-    it('At fully encumbered', () => {
-      const expectedBase = 0;
-      const expectedEncounter = 0;
-      const expectedOverland = 0;
+    it('At 100% encumbered (25% moverate)', () => {
+      const expectedBase = OseDataModelCharacterMove.baseMoveRate * .25;
+      const expectedEncounter = expectedBase / 3;
+      const expectedOverland = expectedBase / 5;
       
       let enc = new EncumbranceDetailed(undefined, [
         createMockItem('item', OseDataModelCharacterEncumbrance.baseEncumbranceCap, 1, {treasure: true}),
@@ -175,9 +231,23 @@ export default ({
       expect(move.encounter).to.equal(expectedEncounter)
       expect(move.overland).to.equal(expectedOverland)
     })
+    it('At 100.1% encumbered (0% moverate)', () => {
+      const expectedBase = 0;
+      const expectedEncounter = 0;
+      const expectedOverland = 0;
+      
+      let enc = new EncumbranceDetailed(undefined, [
+        createMockItem('item', OseDataModelCharacterEncumbrance.baseEncumbranceCap, 1.001, {treasure: true}),
+      ]);
+      let move = new OseDataModelCharacterMove(enc);
+
+      expect(move.base).to.equal(expectedBase);
+      expect(move.encounter).to.equal(expectedEncounter)
+      expect(move.overland).to.equal(expectedOverland)
+    })
   })
   describe('Correctly calculates from Complete Encumbrance', () => {
-    it('At unencumbered', () => {
+    it('At 0% encumbered (100% moverate)', () => {
       const expectedBase = OseDataModelCharacterMove.baseMoveRate;
       const expectedEncounter = expectedBase / 3;
       const expectedOverland = expectedBase / 5;
@@ -186,16 +256,44 @@ export default ({
       let move = new OseDataModelCharacterMove(enc);
 
       expect(move.base).to.equal(expectedBase);
+      expect(move.encounter).to.equal(expectedEncounter);
+      expect(move.overland).to.equal(expectedOverland);
+    })
+    it('At 12.5% encumbered (100% moverate)', () => {
+      const expectedBase = OseDataModelCharacterMove.baseMoveRate;
+      const expectedEncounter = expectedBase / 3;
+      const expectedOverland = expectedBase / 5;
+      
+      let enc = new EncumbranceComplete(undefined, [
+        createMockItem('item', OseDataModelCharacterEncumbrance.baseEncumbranceCap * .125, 1 ),
+      ]);
+      let move = new OseDataModelCharacterMove(enc);
+
+      expect(move.base).to.equal(expectedBase);
       expect(move.encounter).to.equal(expectedEncounter)
       expect(move.overland).to.equal(expectedOverland)
     })
-    it('At 12.5% encumbered', () => {
+    it('At 25% encumbered (100% moverate)', () => {
+      const expectedBase = OseDataModelCharacterMove.baseMoveRate;
+      const expectedEncounter = expectedBase / 3;
+      const expectedOverland = expectedBase / 5;
+      
+      let enc = new EncumbranceComplete(undefined, [
+        createMockItem('item', OseDataModelCharacterEncumbrance.baseEncumbranceCap * .25, 1 ),
+      ]);
+      let move = new OseDataModelCharacterMove(enc);
+
+      expect(move.base).to.equal(expectedBase);
+      expect(move.encounter).to.equal(expectedEncounter)
+      expect(move.overland).to.equal(expectedOverland)
+    })
+    it('At 25.1% encumbered (75% moverate)', () => {
       const expectedBase = OseDataModelCharacterMove.baseMoveRate * .75;
       const expectedEncounter = expectedBase / 3;
       const expectedOverland = expectedBase / 5;
       
       let enc = new EncumbranceComplete(undefined, [
-        createMockItem('item', OseDataModelCharacterEncumbrance.baseEncumbranceCap * .125, 1),
+        createMockItem('item', OseDataModelCharacterEncumbrance.baseEncumbranceCap * .251, 1 ),
       ]);
       let move = new OseDataModelCharacterMove(enc);
 
@@ -203,13 +301,13 @@ export default ({
       expect(move.encounter).to.equal(expectedEncounter)
       expect(move.overland).to.equal(expectedOverland)
     })
-    it('At 25% encumbered', () => {
-      const expectedBase = OseDataModelCharacterMove.baseMoveRate * .5;
+    it('At 37.5% encumbered (75% moverate)', () => {
+      const expectedBase = OseDataModelCharacterMove.baseMoveRate * .75;
       const expectedEncounter = expectedBase / 3;
       const expectedOverland = expectedBase / 5;
       
       let enc = new EncumbranceComplete(undefined, [
-        createMockItem('item', OseDataModelCharacterEncumbrance.baseEncumbranceCap * .25, 1),
+        createMockItem('item', OseDataModelCharacterEncumbrance.baseEncumbranceCap * .375, 1 ),
       ]);
       let move = new OseDataModelCharacterMove(enc);
 
@@ -217,27 +315,69 @@ export default ({
       expect(move.encounter).to.equal(expectedEncounter)
       expect(move.overland).to.equal(expectedOverland)
     })
-    it('At 50% encumbered', () => {
+    it('At 37.51% encumbered (50% moverate)', () => {
+      const expectedBase = OseDataModelCharacterMove.baseMoveRate * .50;
+      const expectedEncounter = expectedBase / 3;
+      const expectedOverland = expectedBase / 5;
+      
+      let enc = new EncumbranceComplete(undefined, [
+        createMockItem('item', OseDataModelCharacterEncumbrance.baseEncumbranceCap * .3751, 1 ),
+      ]);
+      let move = new OseDataModelCharacterMove(enc);
+
+      expect(move.base).to.equal(expectedBase);
+      expect(move.encounter).to.equal(expectedEncounter)
+      expect(move.overland).to.equal(expectedOverland)
+    })
+    it('At 50% encumbered (50% moverate)', () => {
+      const expectedBase = OseDataModelCharacterMove.baseMoveRate * .50;
+      const expectedEncounter = expectedBase / 3;
+      const expectedOverland = expectedBase / 5;
+      
+      let enc = new EncumbranceComplete(undefined, [
+        createMockItem('item', OseDataModelCharacterEncumbrance.baseEncumbranceCap * .5, 1 ),
+      ]);
+      let move = new OseDataModelCharacterMove(enc);
+
+      expect(move.base).to.equal(expectedBase);
+      expect(move.encounter).to.equal(expectedEncounter)
+      expect(move.overland).to.equal(expectedOverland)
+    })
+    it('At 50.1% encumbered (25% moverate)', () => {
       const expectedBase = OseDataModelCharacterMove.baseMoveRate * .25;
       const expectedEncounter = expectedBase / 3;
       const expectedOverland = expectedBase / 5;
       
       let enc = new EncumbranceComplete(undefined, [
-        createMockItem('item', OseDataModelCharacterEncumbrance.baseEncumbranceCap * .75, 1),
+        createMockItem('item', OseDataModelCharacterEncumbrance.baseEncumbranceCap * .501, 1 ),
       ]);
       let move = new OseDataModelCharacterMove(enc);
 
+      expect(move.base).to.equal(expectedBase);
       expect(move.encounter).to.equal(expectedEncounter)
       expect(move.overland).to.equal(expectedOverland)
-      expect(move.base).to.equal(OseDataModelCharacterMove.baseMoveRate * .25);
     })
-    it('At fully encumbered', () => {
+    it('At 100% encumbered (25% moverate)', () => {
+      const expectedBase = OseDataModelCharacterMove.baseMoveRate * .25;
+      const expectedEncounter = expectedBase / 3;
+      const expectedOverland = expectedBase / 5;
+      
+      let enc = new EncumbranceComplete(undefined, [
+        createMockItem('item', OseDataModelCharacterEncumbrance.baseEncumbranceCap, 1 ),
+      ]);
+      let move = new OseDataModelCharacterMove(enc);
+
+      expect(move.base).to.equal(expectedBase);
+      expect(move.encounter).to.equal(expectedEncounter)
+      expect(move.overland).to.equal(expectedOverland)
+    })
+    it('At 100.1% encumbered (0% moverate)', () => {
       const expectedBase = 0;
       const expectedEncounter = 0;
       const expectedOverland = 0;
       
       let enc = new EncumbranceComplete(undefined, [
-        createMockItem('item', OseDataModelCharacterEncumbrance.baseEncumbranceCap, 1),
+        createMockItem('item', OseDataModelCharacterEncumbrance.baseEncumbranceCap, 1.001 ),
       ]);
       let move = new OseDataModelCharacterMove(enc);
 

--- a/src/module/actor/data-model-classes/data-model-character-encumbrance-basic.ts
+++ b/src/module/actor/data-model-classes/data-model-character-encumbrance-basic.ts
@@ -92,7 +92,7 @@ export default class OseDataModelCharacterEncumbranceBasic extends OseDataModelC
 			this.value >=	this.#treasureEncumbrance
 		);
 	}
-	get atQuarterEncumbered() { 
+	get atThreeEighthsEncumbered() { 
 		const isHeavy = this.#heaviestArmor === OseDataModelCharacterEncumbranceBasic.armorWeight.heavy;
 		const isLightWithTreasure = (
 			this.#heaviestArmor === OseDataModelCharacterEncumbranceBasic.armorWeight.light &&
@@ -100,7 +100,7 @@ export default class OseDataModelCharacterEncumbranceBasic extends OseDataModelC
 		);	
 		return isHeavy || isLightWithTreasure;
 	}
-	get atEighthEncumbered()	{
+	get atQuarterEncumbered()	{
 		return (
 			this.#heaviestArmor === OseDataModelCharacterEncumbranceBasic.armorWeight.light ||
 			this.overSignificantTreasureThreshold

--- a/src/module/actor/data-model-classes/data-model-character-encumbrance.ts
+++ b/src/module/actor/data-model-classes/data-model-character-encumbrance.ts
@@ -7,8 +7,8 @@ export interface CharacterEncumbrance {
   value: number;
   max: number;
   atHalfEncumbered: boolean | null;
+  atThreeEighthsEncumbered: boolean | null;
   atQuarterEncumbered: boolean | null;
-  atEighthEncumbered: boolean | null;
 };
 
 /**
@@ -17,8 +17,8 @@ export interface CharacterEncumbrance {
  export default class OseDataModelCharacterEncumbrance implements CharacterEncumbrance {
   static baseEncumbranceCap = 1600;
   static encumbranceSteps = {
-    eighth: 12.5,
     quarter: 25,
+    threeEighths: 37.5,
     half: 50
   };
 
@@ -49,7 +49,7 @@ export interface CharacterEncumbrance {
     return Math.clamped((100 * this.value) / this.max, 0, 100)
   };
   get encumbered() {
-    return this.value >= this.max;
+    return this.value > this.max;
   }
   get steps(): number[] {
     return [];
@@ -64,13 +64,13 @@ export interface CharacterEncumbrance {
   get #delta() { return this.max - OseDataModelCharacterEncumbrance.baseEncumbranceCap; };
 
   get atHalfEncumbered() {
-    return this.value >= this.max * (OseDataModelCharacterEncumbrance.encumbranceSteps.half / 100) + (this.#delta || 0)
+    return this.value > this.max * (OseDataModelCharacterEncumbrance.encumbranceSteps.half / 100) + (this.#delta || 0)
+  }
+  get atThreeEighthsEncumbered() {
+    return this.value > this.max * (OseDataModelCharacterEncumbrance.encumbranceSteps.threeEighths / 100) + (this.#delta || 0)
   }
   get atQuarterEncumbered() {
-    return this.value >= this.max * (OseDataModelCharacterEncumbrance.encumbranceSteps.quarter / 100) + (this.#delta || 0)
-  }
-  get atEighthEncumbered() {
-    return this.value >= this.max * (OseDataModelCharacterEncumbrance.encumbranceSteps.eighth / 100) + (this.#delta || 0)
+    return this.value > this.max * (OseDataModelCharacterEncumbrance.encumbranceSteps.quarter / 100) + (this.#delta || 0)
   }
   
 }

--- a/src/module/actor/data-model-classes/data-model-character-move.ts
+++ b/src/module/actor/data-model-classes/data-model-character-move.ts
@@ -20,8 +20,8 @@ export default class OseDataModelCharacterMove implements CharacterMove {
   #overEncumbranceLimit;
   
   #halfEncumbered;
+  #threeEighthsEncumbered;
   #quarterEncumbered;
-  #eighthEncumbered;
   
   /**
    * 
@@ -42,15 +42,15 @@ export default class OseDataModelCharacterMove implements CharacterMove {
 
     // Non-basic encumbrance variant props
     this.#halfEncumbered    = encumbrance.atHalfEncumbered;
-    this.#quarterEncumbered = encumbrance.atQuarterEncumbered;
-    this.#eighthEncumbered  = encumbrance.atEighthEncumbered;
+    this.#threeEighthsEncumbered = encumbrance.atThreeEighthsEncumbered;
+    this.#quarterEncumbered  = encumbrance.atQuarterEncumbered;
   }
 
   #derivedSpeed() {
     if (this.#overEncumbranceLimit)    return 0;
     else if (this.#halfEncumbered)     return this.#moveBase * .25;
-    else if (this.#quarterEncumbered)  return this.#moveBase * .50;
-    else if (this.#eighthEncumbered)   return this.#moveBase * .75;
+    else if (this.#threeEighthsEncumbered)  return this.#moveBase * .50;
+    else if (this.#quarterEncumbered)   return this.#moveBase * .75;
     else                               return this.#moveBase;
   }
   


### PR DESCRIPTION
Fixes #315.

- Quarter encumbrance is now 75% base movement
- Instead of eighth encumbrance at 75% base movement, it's three-eighths encumbrance at 50% base movement
- Weight equal to each encumbrance step `[400, 600, 800, 1600]` is now correctly evaluated to `[100, 75, 50, 25]` % base movement. Weight *above* each step will step up the encumbrance!
- Additional tests added

Since the incorrect `>=` used for each encumbrance step is technically a regression, I hope you can appreciate the utility in the additional tests. These should make sure we don't make that mistake again.