### PR TITLE
chore: data migration to default img

### DIFF
--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -11,7 +11,7 @@ export class OseActor extends Actor {
     if (!source.img) {
       source.img = 'icons/svg/mystery-man.svg';
     }
-    if (!source.prototypeToken.texture.img) {
+    if (!source.prototypeToken?.texture?.img) {
       source.prototypeToken.texture.img = 'icons/svg/mystery-man.svg';
     }
 		return source

--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -7,6 +7,16 @@ export class OseActor extends Actor {
     this.system.prepareDerivedData?.();
   }
 
+  static migrateData(source) {
+    if (!source.img) {
+      source.img = 'icons/svg/mystery-man.svg';
+    }
+    if (!source.prototypeToken.texture.img) {
+      source.prototypeToken.texture.img = 'icons/svg/mystery-man.svg';
+    }
+		return source
+	}
+
   static async update(data, options = {}) {
     // Compute AAC from AC
     if (data?.ac?.value) {

--- a/src/module/item/entity.js
+++ b/src/module/item/entity.js
@@ -24,6 +24,13 @@ export class OseItem extends Item {
     return super.create(data, context);
   }
 
+  static migrateData(source) {
+    if (!source.img && source.type) {
+      source.img = this.defaultIcons(source.type)
+    }
+		return source
+	}
+
   prepareData() {
     super.prepareData();
   }


### PR DESCRIPTION
resolves #32

- Migrate any missing `img` for actors, tokens, and items.