### PR TITLE
fix: Container streamlining

### DIFF
--- a/src/e2e/actor/character-rolling.e2e.test.js
+++ b/src/e2e/actor/character-rolling.e2e.test.js
@@ -3,9 +3,9 @@
  */
 import { trashChat, waitForInput } from "../testUtils";
 
-export const key = "ose.actor.character";
+export const key = "ose.actor.character.rolling";
 export const options = {
-  displayName: "The Character Sheet",
+  displayName: "Actor Data Model: Character Rolling",
 };
 
 /**
@@ -23,17 +23,12 @@ export const closeRollDialog = async () => {
   });
 };
 
-export default ({
-  before,
-  beforeEach,
-  after,
-  afterEach,
-  describe,
-  it,
-  expect,
-  ...context
-}) => {
+export default ({ before, beforeEach, after, describe, it, expect }) => {
   const testCharacterName = "Quench Test Character";
+
+  const testActor = () => game.actors.getName(testCharacterName);
+  const trashActor = () => testActor()?.delete();
+
   const prepareActor = async (data) => {
     await trashChat();
     await trashActor();
@@ -45,31 +40,30 @@ export default ({
     });
   };
 
-  const testActor = () => game.actors.getName(testCharacterName);
-  const trashActor = () => testActor()?.delete();
-
-  const rollNoMods = async (key, rollFn) => {
-    await testActor()[rollFn](key, { fastForward: true });
+  const rollNoMods = async (rollKey, rollFn) => {
+    await testActor()[rollFn](rollKey, { fastForward: true });
     await waitForInput();
     expect(game.messages.size).to.equal(1);
   };
 
-  const rollNoModsSkipDialog = async (key, rollFn) => {
-    const ctrl_down = new KeyboardEvent("keydown", { ctrlKey: true });
-    await testActor()[rollFn](key, { event: ctrl_down });
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const rollNoModsSkipDialog = async (rollKey, rollFn) => {
+    const ctrlDown = new KeyboardEvent("keydown", { ctrlKey: true });
+    await testActor()[rollFn](rollKey, { event: ctrlDown });
     await waitForInput();
     expect(game.messages.size).to.equal(1);
   };
 
-  const rollNoModsSkipDialogMeta = async (key, rollFn) => {
-    const meta_down = new KeyboardEvent("keydown", { metaKey: true });
-    await testActor()[rollFn](key, { event: meta_down });
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const rollNoModsSkipDialogMeta = async (rollKey, rollFn) => {
+    const metaDown = new KeyboardEvent("keydown", { metaKey: true });
+    await testActor()[rollFn](rollKey, { event: metaDown });
     await waitForInput();
     expect(game.messages.size).to.equal(1);
   };
 
-  const rollMods = async (key, rollFn) => {
-    testActor()[rollFn](key);
+  const rollMods = async (rollKey, rollFn) => {
+    testActor()[rollFn](rollKey);
 
     await waitForInput();
 
@@ -85,92 +79,15 @@ export default ({
     expect(game.messages.size).to.equal(1);
   };
 
-  const rollInvertCtrlNoDialog = async (key, rollFn) => {
-    await testActor()[rollFn](key, { fastForward: false });
-    await waitForInput();
-
-    expect(game.messages.size).to.equal(1);
-  };
-
-  const rollInvertCtrlDialog = async (key, rollFn) => {
-    const ctrl_down = new KeyboardEvent("keydown", { ctrlKey: true });
-    testActor()[rollFn](key, { event: ctrl_down });
-
-    await waitForInput();
-
-    const dialog = document.querySelector(".roll-dialog.ose");
-    expect(dialog).not.equal(null);
-
-    dialog
-      .closest(".window-content")
-      .querySelector(".dialog-button.ok")
-      .click();
-
-    await waitForInput();
-    expect(game.messages.size).to.equal(1);
-  };
-
-  const rollInvertCtrlDialogMeta = async (key, rollFn) => {
-    const meta_down = new KeyboardEvent("keydown", { metaKey: true });
-    testActor()[rollFn](key, { event: meta_down });
-
-    await waitForInput();
-
-    const dialog = document.querySelector(".roll-dialog.ose");
-    expect(dialog).not.equal(null);
-
-    dialog
-      .closest(".window-content")
-      .querySelector(".dialog-button.ok")
-      .click();
-
-    await waitForInput();
-    expect(game.messages.size).to.equal(1);
-  };
-
-  const canRoll = (key, rollFn) => {
-    before(async () => {
-      await game.settings.set(game.system.id, "invertedCtrlBehavior", false);
-    });
-
+  const canRoll = (rollKey, rollFn) => {
     beforeEach(async () => {
       await trashChat();
     });
-
-    afterEach(async () => {
-      await closeRollDialog();
-    });
     it("With no modifiers", async () => {
-      await rollNoMods(key, rollFn);
-    });
-    it("Skipping dialog, holding ctrl", async () => {
-      await rollNoModsSkipDialog(key, rollFn);
-    });
-    it("Skipping dialog, holding meta", async () => {
-      await rollNoModsSkipDialogMeta(key, rollFn);
+      await rollNoMods(rollKey, rollFn);
     });
     it("With modifiers", async () => {
-      await rollMods(key, rollFn);
-    });
-
-    describe("Inverted Ctrl behavior", () => {
-      before(async () => {
-        await game.settings.set(game.system.id, "invertedCtrlBehavior", true);
-      });
-
-      after(async () => {
-        await game.settings.set(game.system.id, "invertedCtrlBehavior", false);
-      });
-
-      it("Inverted ctrl behavior without dialog", async () => {
-        await rollInvertCtrlNoDialog(key, rollFn);
-      });
-      it("Inverted ctrl behavior with dialog, ctrl key", async () => {
-        await rollInvertCtrlDialog(key, rollFn);
-      });
-      it("Inverted ctrl behavior with dialog, meta key", async () => {
-        await rollInvertCtrlDialogMeta(key, rollFn);
-      });
+      await rollMods(rollKey, rollFn);
     });
   };
 
@@ -185,6 +102,7 @@ export default ({
     });
 
     it("renders", async () => {
+      // eslint-disable-next-line no-underscore-dangle
       await testActor().sheet._render(true);
       expect(document.querySelector(".sheet.character")).not.to.be.null;
       await testActor().sheet.close();
@@ -194,7 +112,8 @@ export default ({
   describe("The Attributes Tab", () => {
     // At01
     describe("Scores", () => {
-      const canRollCheck = (key) => canRoll(key, "rollCheck");
+      // eslint-disable-next-line unicorn/consistent-function-scoping
+      const canRollCheck = (rollKey) => canRoll(rollKey, "rollCheck");
 
       before(async () => {
         await prepareActor();
@@ -232,7 +151,8 @@ export default ({
 
     // At02
     describe("Saves", () => {
-      const canRollSave = (key) => canRoll(key, "rollSave");
+      // eslint-disable-next-line unicorn/consistent-function-scoping
+      const canRollSave = (rollKey) => canRoll(rollKey, "rollSave");
 
       before(async () => {
         await prepareActor();
@@ -267,7 +187,9 @@ export default ({
   describe("The Abilities Tab", () => {
     // Ab01
     describe("Exploration Skills", () => {
-      const canRollExploration = (key) => canRoll(key, "rollExploration");
+      // eslint-disable-next-line unicorn/consistent-function-scoping
+      const canRollExploration = (rollKey) =>
+        canRoll(rollKey, "rollExploration");
 
       before(async () => {
         await prepareActor();

--- a/src/e2e/index.ts
+++ b/src/e2e/index.ts
@@ -5,6 +5,10 @@
 /**
  * @file Orchestration for our Quench tests
  */
+import actorCrudInventoryWeaponTests, {
+  key as actorCrudInventoryWeaponKey,
+  options as actorCrudInventoryWeaponOptions,
+} from "../module/actor/__tests__/character-crud-inventory-weapon.test";
 import actorCrudInventoryContainerTests, {
   key as actorCrudInventoryContainerKey,
   options as actorCrudInventoryContainerOptions,
@@ -48,6 +52,11 @@ type Quench = {
 
 Hooks.on("quenchReady", async (quench: Quench) => {
   // Actor CRUD testing
+  quench.registerBatch(
+    actorCrudInventoryWeaponKey,
+    actorCrudInventoryWeaponTests,
+    actorCrudInventoryWeaponOptions
+  );
   quench.registerBatch(
     actorCrudInventoryContainerKey,
     actorCrudInventoryContainerTests,

--- a/src/e2e/index.ts
+++ b/src/e2e/index.ts
@@ -1,10 +1,18 @@
+/* eslint-disable eslint-comments/disable-enable-pair */
+
+/* eslint-disable import/no-cycle, simple-import-sort/imports */
+
 /**
  * @file Orchestration for our Quench tests
  */
+import actorCrudInventoryContainerTests, {
+  key as actorCrudInventoryContainerKey,
+  options as actorCrudInventoryContainerOptions,
+} from "../module/actor/__tests__/character-crud-inventory-container.test";
 import dataModelCharacterTests, {
   key as dataModelCharacterKey,
   options as dataModelCharacterOptions,
-} from "../module/actor/data-model-character.test.js";
+} from "../module/actor/data-model-character.test";
 import dataModelCharacterACTests, {
   key as dataModelCharacterACKey,
   options as dataModelCharacterACOptions,
@@ -25,14 +33,10 @@ import dataModelCharacterSpellsTests, {
   key as dataModelCharacterSpellsKey,
   options as dataModelCharacterSpellsOptions,
 } from "../module/actor/data-model-classes/__tests__/data-model-character-spells.test";
-import characterTests, {
-  key as characterKey,
-  options as characterOptions,
-} from "./actor/character.e2e.test.js";
-import characterItemMacroTests, {
-  key as characterItemMacroKey,
-  options as characterItemMacroOptions,
-} from "./actor/createItemMacro.test";
+import characterRollingTests, {
+  key as characterRollingKey,
+  options as characterRollingOptions,
+} from "./actor/character-rolling.e2e.test";
 
 export type QuenchMethods = {
   [s: string]: any;
@@ -43,13 +47,24 @@ type Quench = {
 };
 
 Hooks.on("quenchReady", async (quench: Quench) => {
+  // Actor CRUD testing
   quench.registerBatch(
-    characterItemMacroKey,
-    characterItemMacroTests,
-    characterItemMacroOptions
+    actorCrudInventoryContainerKey,
+    actorCrudInventoryContainerTests,
+    actorCrudInventoryContainerOptions
   );
-  quench.registerBatch(characterKey, characterTests, characterOptions);
+  // Actor rolling testing
+  quench.registerBatch(
+    characterRollingKey,
+    characterRollingTests,
+    characterRollingOptions
+  );
   // Character data model classes
+  quench.registerBatch(
+    dataModelCharacterKey,
+    dataModelCharacterTests,
+    dataModelCharacterOptions
+  );
   quench.registerBatch(
     dataModelCharacterACKey,
     dataModelCharacterACTests,
@@ -74,10 +89,5 @@ Hooks.on("quenchReady", async (quench: Quench) => {
     dataModelCharacterMoveKey,
     dataModelCharacterMoveTests,
     dataModelCharacterMoveOptions
-  );
-  quench.registerBatch(
-    dataModelCharacterKey,
-    dataModelCharacterTests,
-    dataModelCharacterOptions
   );
 });

--- a/src/module/actor/__tests__/character-crud-inventory-container.test.js
+++ b/src/module/actor/__tests__/character-crud-inventory-container.test.js
@@ -1,0 +1,263 @@
+/**
+ * @file Cotains Quench for containers in actor sheets
+ */
+import { trashChat, waitForInput } from "../../../e2e/testUtils";
+
+export const key = "ose.actor.crud.inventory.container";
+export const options = {
+  displayName: "Actor CRUD: Inventory, Container",
+};
+
+const createWorldTestItem = async (type) =>
+  Item.create({
+    type,
+    name: `New World Test ${type.capitalize()}`,
+  });
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const deleteWorldTestItem = async (type) => {
+  game.items.getName(`New World Test ${type.capitalize()}`).delete();
+};
+
+const createTestCompendium = async () =>
+  // eslint-disable-next-line no-undef
+  CompendiumCollection.createCompendium({
+    id: "world.compendiumtest",
+    label: "Compendium Test",
+    name: "compendiumtest",
+    type: "Item",
+  });
+
+const deleteTestCompendium = async () => {
+  game.packs.get("world.compendiumtest")?.deleteCompendium();
+};
+
+export default ({
+  before,
+  beforeEach,
+  after,
+  afterEach,
+  expect,
+  describe,
+  it,
+}) => {
+  const testCharacterName = "Quench Test Character";
+
+  const testActor = () => game.actors.getName(testCharacterName);
+  const testActorSheet = () => testActor()?.sheet;
+  const trashActor = () => testActor()?.delete();
+  const trashItems = () => {
+    testActor()?.items?.forEach((o) => o.delete());
+    game.items
+      .filter((o) => o.name.includes("New World Test"))
+      .forEach((o) => o.delete());
+  };
+
+  const prepareActor = async (data) => {
+    await trashChat();
+    await trashActor();
+
+    return Actor.create({
+      ...data,
+      name: testCharacterName,
+      type: "character",
+    });
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const renderInventory = async () => {
+    // eslint-disable-next-line no-underscore-dangle
+    await testActor().sheet._render(true);
+  };
+
+  /* --------------------------------------- */
+
+  const createActorTestItem = async (type) =>
+    testActor().createEmbeddedDocuments(
+      "Item",
+      [{ type, name: `New Actor Test ${type.capitalize()}` }],
+      {}
+    );
+
+  /* --------------------------------------- */
+
+  const testAddContainerToActor = async () => {
+    expect(testActor().items.size).equals(0);
+    const testItem = await createActorTestItem("container");
+    expect(testActor().items.size).equals(1);
+    expect(testItem.length).equals(1);
+    expect(testItem[0].name).equals("New Actor Test Container");
+    expect(testActor().system.containers.length).equal(1);
+  };
+
+  const testAddContainerAndItem = async () => {
+    await testAddContainerToActor();
+    await createActorTestItem("item");
+    expect(testActor().items.size).equals(2);
+    expect(testActor().system.items.length).equal(1);
+  };
+
+  const testAddWorldItem = async () => {
+    expect(game.items.getName("New World Test Item")).is.undefined;
+    await createWorldTestItem("item");
+    const testItem = game.items.getName("New World Test Item");
+    expect(testItem).is.not.undefined;
+    return testItem;
+  };
+
+  /* --------------------------------------- */
+
+  const testMoveItemToContainer = async (sourceItem, targetItem) => {
+    // eslint-disable-next-line no-underscore-dangle
+    await testActorSheet()._onContainerItemAdd(sourceItem, targetItem);
+
+    // eslint-disable-next-line no-underscore-dangle
+    expect(sourceItem.system.containerId).equals(targetItem._id);
+    expect(targetItem.system.itemIds.length).equals(1);
+    // eslint-disable-next-line no-underscore-dangle
+    expect(targetItem.system.itemIds[0]).equals(sourceItem._id);
+    expect(testActor().system.containers.length).equal(1);
+    expect(testActor().system.items.length).equal(0);
+  };
+
+  /* --------------------------------------- */
+
+  const testSetupContainerAndItem = async () => {
+    await testAddContainerAndItem();
+    const sourceItem = testActor().items.getName("New Actor Test Item");
+    const targetItem = testActor().items.getName("New Actor Test Container");
+    await testMoveItemToContainer(sourceItem, targetItem);
+    expect(testActor().items.size).equals(2);
+    expect(testActor().system.containers.length).equal(1);
+    expect(testActor().system.items.length).equal(0);
+  };
+
+  /* --------------------------------------- */
+
+  before(async () => {
+    await trashChat();
+    await prepareActor();
+  });
+
+  after(async () => {
+    await trashChat();
+    await trashActor();
+  });
+
+  afterEach(async () => {
+    trashItems();
+    await deleteTestCompendium();
+    await waitForInput();
+  });
+
+  /* --------------------------------------- */
+
+  describe("Creating", () => {
+    it("Creating a container item on the Actor", async () => {
+      await testAddContainerToActor();
+    });
+    it("Adding item from the actor itself into Actor container", async () => {
+      await testAddContainerAndItem();
+    });
+    it("Adding item from Items sidebar into Actor container", async () => {
+      const testItem = await testAddWorldItem();
+
+      await testAddContainerToActor();
+
+      const testContainer = testActor().items.getName(
+        "New Actor Test Container"
+      );
+      // eslint-disable-next-line no-underscore-dangle
+      await testActorSheet()._onContainerItemAdd(testItem, testContainer);
+
+      const testItemActor = testActor().items.getName("New World Test Item");
+      // eslint-disable-next-line no-underscore-dangle
+      expect(testItemActor.system.containerId).equals(testContainer._id);
+      expect(testContainer.system.itemIds.length).equals(1);
+      // eslint-disable-next-line no-underscore-dangle
+      expect(testContainer.system.itemIds[0]).equals(testItemActor._id);
+      expect(testActor().system.containers.length).equal(1);
+      expect(testActor().system.items.length).equal(0);
+    });
+    it("Adding item from Item Compendium into Actor container", async () => {
+      expect(game.packs.get("world.testcompendiumtest")).undefined;
+      await createTestCompendium();
+      expect(game.packs.get("world.compendiumtest")).not.undefined;
+      expect(game.packs.get("world.compendiumtest").size).equal(0);
+
+      const testWorldItem = await testAddWorldItem();
+
+      await game.packs
+        .get("world.compendiumtest")
+        .importDocument(testWorldItem);
+      expect(game.packs.get("world.compendiumtest").size).equal(1);
+
+      const testItem = game.packs.get("world.compendiumtest").contents[0];
+      expect(testItem).not.undefined;
+
+      await testAddContainerToActor();
+      const testContainer = testActor().items.getName(
+        "New Actor Test Container"
+      );
+      // eslint-disable-next-line no-underscore-dangle
+      await testActorSheet()._onContainerItemAdd(testItem, testContainer);
+
+      const testItemActor = testActor().items.getName("New World Test Item");
+      // eslint-disable-next-line no-underscore-dangle
+      expect(testItemActor.system.containerId).equals(testContainer._id);
+      expect(testContainer.system.itemIds.length).equals(1);
+      // eslint-disable-next-line no-underscore-dangle
+      expect(testContainer.system.itemIds[0]).equals(testItemActor._id);
+      expect(testActor().system.containers.length).equal(1);
+      expect(testActor().system.items.length).equal(0);
+    });
+  });
+
+  describe("Removing", () => {
+    beforeEach(async () => {
+      await testSetupContainerAndItem();
+    });
+
+    // it('Trying to remove container with items asks for confirmation', () => {})
+    // it('Confirmed deletion pops contained items into inventory', () => {})
+    // it('Cancelled confirmation cancels leaves container & inventory as-is', () => {})
+    it("Removing contained item updates containers internal id list", async () => {
+      const testItem = testActor().items.getName("New Actor Test Item");
+      const testContainer = testActor().items.getName(
+        "New Actor Test Container"
+      );
+      expect(testItem).not.undefined;
+      expect(testContainer).not.undefined;
+
+      // eslint-disable-next-line no-underscore-dangle
+      await testActorSheet()._removeItemFromActor(testItem);
+      await waitForInput();
+      expect(testActor().system.containers.length).equal(1);
+      expect(testContainer.system.itemIds.length).equal(0);
+      expect(testActor().system.items.length).equal(0);
+    });
+    it("Dragging contained item into inventory again removes it from container", async () => {
+      const testItem = testActor().items.getName("New Actor Test Item");
+      const testContainer = testActor().items.getName(
+        "New Actor Test Container"
+      );
+      expect(testItem).not.undefined;
+      expect(testContainer).not.undefined;
+
+      // eslint-disable-next-line no-underscore-dangle
+      await testActorSheet()._onContainerItemRemove(testItem, testContainer);
+      await waitForInput();
+      expect(testActor().system.containers.length).equal(1);
+      expect(testContainer.system.itemIds.length).equal(0);
+      expect(testActor().system.items.length).equal(1);
+      expect(testItem.system.containerId).equal("");
+    });
+  });
+  // describe('Updating', () => {
+  //     it('Updating the container description shows up in actor sheet', () => {})
+  // })
+  // describe('Displaying', () => {
+  //     it('Clicking on an item in inventory expands to show summary', () => {})
+  //     it('Clicking the container icon displays container & its contents to chat', () => {})
+  // })
+};

--- a/src/module/actor/__tests__/character-crud-inventory-weapon.test.ts
+++ b/src/module/actor/__tests__/character-crud-inventory-weapon.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @file Contains Quench for weapons in actor sheets
+ */
+import { trashChat } from "../../../e2e/testUtils";
+
+export const key = "ose.actor.crud.inventory.weapon";
+export const options = {
+  displayName: "Actor CRUD: Inventory, Weapon",
+};
+
+export default ({ before, after, expect, describe, it }) => {
+  const testCharacterName = "Quench Test Character";
+
+  const testActor = () => game?.actors?.getName(testCharacterName);
+  const trashActor = () => testActor()?.delete();
+
+  const prepareActor = async (data = {}) => {
+    await trashChat();
+    await trashActor();
+
+    return Actor.create({
+      ...data,
+      name: testCharacterName,
+      type: "character",
+    });
+  };
+
+  /* --------------------------------------- */
+
+  const createActorTestItem = async (type: string) =>
+    // eslint-disable-next-line no-underscore-dangle
+    testActor()?.sheet?._createItem(type);
+
+  /* --------------------------------------- */
+
+  before(async () => {
+    await trashChat();
+    await prepareActor();
+  });
+
+  after(async () => {
+    await trashChat();
+    await trashActor();
+  });
+
+  /* --------------------------------------- */
+
+  describe("Creating", () => {
+    it("Creating a weapon item on the Actor", async () => {
+      const weapon: Item = await createActorTestItem("weapon");
+      expect(weapon.length).equal(1);
+      expect(weapon[0].name).equal("New Weapon");
+    });
+  });
+
+  describe("Removing", () => {});
+  describe("Updating", () => {});
+  describe("Displaying", () => {});
+};

--- a/src/module/actor/actor-sheet.js
+++ b/src/module/actor/actor-sheet.js
@@ -5,6 +5,10 @@ import { skipRollDialogCheck } from "../behaviourHelpers";
 import OSE from "../config";
 import OseEntityTweaks from "../dialog/entity-tweaks";
 
+const cssClassItemEntry = ".item-entry";
+const cssClassCaretRight = "fa-caret-right";
+const cssClassCaretDown = "fa-caret-down";
+
 export default class OseActorSheet extends ActorSheet {
   getData() {
     const data = foundry.utils.deepClone(super.getData().data);
@@ -32,13 +36,15 @@ export default class OseActorSheet extends ActorSheet {
 
   // Helpers
 
+  // eslint-disable-next-line no-underscore-dangle
   _getItemFromActor(event) {
-    const li = event.currentTarget.closest(".item-entry");
+    const li = event.currentTarget.closest(cssClassItemEntry);
     return this.actor.items.get(li.dataset.itemId);
   }
 
   // end Helpers
 
+  // eslint-disable-next-line no-underscore-dangle, class-methods-use-this
   _toggleItemCategory(event) {
     event.preventDefault();
     const targetCategory = $(event.currentTarget);
@@ -46,19 +52,20 @@ export default class OseActorSheet extends ActorSheet {
 
     if (items.css("display") === "none") {
       const el = $(event.currentTarget).find(".fas.fa-caret-right");
-      el.removeClass("fa-caret-right");
-      el.addClass("fa-caret-down");
+      el.removeClass(cssClassCaretRight);
+      el.addClass(cssClassCaretDown);
 
       items.slideDown(200);
     } else {
       const el = $(event.currentTarget).find(".fas.fa-caret-down");
-      el.removeClass("fa-caret-down");
-      el.addClass("fa-caret-right");
+      el.removeClass(cssClassCaretDown);
+      el.addClass(cssClassCaretRight);
 
       items.slideUp(200);
     }
   }
 
+  // eslint-disable-next-line no-underscore-dangle, class-methods-use-this
   _toggleContainedItems(event) {
     event.preventDefault();
     const targetItems = $(event.target.closest(".container"));
@@ -66,19 +73,20 @@ export default class OseActorSheet extends ActorSheet {
 
     if (items.css("display") === "none") {
       const el = targetItems.find(".fas.fa-caret-right");
-      el.removeClass("fa-caret-right");
-      el.addClass("fa-caret-down");
+      el.removeClass(cssClassCaretRight);
+      el.addClass(cssClassCaretDown);
 
       items.slideDown(200);
     } else {
       const el = targetItems.find(".fas.fa-caret-down");
-      el.removeClass("fa-caret-down");
-      el.addClass("fa-caret-right");
+      el.removeClass(cssClassCaretDown);
+      el.addClass(cssClassCaretRight);
 
       items.slideUp(200);
     }
   }
 
+  // eslint-disable-next-line no-underscore-dangle, class-methods-use-this
   _toggleItemSummary(event) {
     event.preventDefault();
     const itemSummary = event.currentTarget
@@ -87,19 +95,31 @@ export default class OseActorSheet extends ActorSheet {
     itemSummary.style.display = itemSummary.style.display === "" ? "block" : "";
   }
 
+  // eslint-disable-next-line no-underscore-dangle
   async _displayItemInChat(event) {
-    const li = $(event.currentTarget).closest(".item-entry");
+    const li = $(event.currentTarget).closest(cssClassItemEntry);
     const item = this.actor.items.get(li.data("itemId"));
     item.show();
   }
 
-  async _removeItemFromActor(event) {
-    const item = this._getItemFromActor(event);
-    const itemData = item?.system;
-    const itemDisplay = event.currentTarget.closest(".item-entry");
+  // eslint-disable-next-line no-underscore-dangle, consistent-return
+  async _removeItemFromActor(item) {
+    if (item.type === "ability" || item.type === "spell") {
+      // eslint-disable-next-line no-underscore-dangle
+      return this.actor.deleteEmbeddedDocuments("Item", [item._id]);
+    }
+    if (item.type !== "container" && item.system.containerId !== "") {
+      const { containerId } = item.system;
+      const newItemIds = this.actor.items
+        .get(containerId)
+        .system.itemIds.filter((o) => o !== item.id);
 
-    if (item.type === "container" && itemData.itemIds) {
-      const containedItems = itemData.itemIds;
+      await this.actor.updateEmbeddedDocuments("Item", [
+        { _id: containerId, system: { itemIds: newItemIds } },
+      ]);
+    }
+    if (item.type === "container" && item.system.itemIds) {
+      const containedItems = item.system.itemIds;
       const updateData = containedItems.reduce((acc, val) => {
         acc.push({ _id: val, "system.containerId": "" });
         return acc;
@@ -107,41 +127,46 @@ export default class OseActorSheet extends ActorSheet {
 
       await this.actor.updateEmbeddedDocuments("Item", updateData);
     }
-    this.actor.deleteEmbeddedDocuments("Item", [itemDisplay.dataset.itemId]);
+
+    // eslint-disable-next-line no-underscore-dangle
+    this.actor.deleteEmbeddedDocuments("Item", [item._id]);
   }
 
-  /**
-   * @param event
-   * @param {bool} decrement
-   */
+  // eslint-disable-next-line no-underscore-dangle, consistent-return
   _useConsumable(event, decrement) {
+    // eslint-disable-next-line no-underscore-dangle
     const item = this._getItemFromActor(event);
     if (!item) return null;
     let {
       quantity: { value: quantity },
     } = item.system;
+    quantity = decrement ? quantity + 1 : quantity - 1;
     item.update({
-      "system.quantity.value": decrement ? --quantity : ++quantity,
+      "system.quantity.value": quantity,
     });
   }
 
+  // eslint-disable-next-line no-underscore-dangle, consistent-return
   async _onSpellChange(event) {
     event.preventDefault();
+    // eslint-disable-next-line no-underscore-dangle
     const item = this._getItemFromActor(event);
     if (event.target.dataset.field === "cast") {
-      return item.update({ "system.cast": parseInt(event.target.value) });
+      return item.update({ "system.cast": parseInt(event.target.value, 10) });
     }
     if (event.target.dataset.field === "memorize") {
       return item.update({
-        "system.memorized": parseInt(event.target.value),
+        "system.memorized": parseInt(event.target.value, 10),
       });
     }
   }
 
+  // eslint-disable-next-line no-underscore-dangle
   async _resetSpells(event) {
     const spells = $(event.currentTarget)
       .closest(".inventory.spells")
-      .find(".item-entry");
+      // eslint-disable-next-line unicorn/no-array-callback-reference
+      .find(cssClassItemEntry);
     spells.each((_, el) => {
       const { itemId } = el.dataset;
       const item = this.actor.items.get(itemId);
@@ -153,7 +178,9 @@ export default class OseActorSheet extends ActorSheet {
     });
   }
 
+  // eslint-disable-next-line no-underscore-dangle
   async _rollAbility(event) {
+    // eslint-disable-next-line no-underscore-dangle
     const item = this._getItemFromActor(event);
     const itemData = item?.system;
     if (item.type === "weapon") {
@@ -163,13 +190,14 @@ export default class OseActorSheet extends ActorSheet {
         });
       }
       item.rollWeapon({ skipDialog: skipRollDialogCheck(event) });
-    } else if (item.type == "spell") {
+    } else if (item.type === "spell") {
       item.spendSpell({ skipDialog: skipRollDialogCheck(event) });
     } else {
       item.rollFormula({ skipDialog: skipRollDialogCheck(event) });
     }
   }
 
+  // eslint-disable-next-line no-underscore-dangle
   async _rollSave(event) {
     const actorObject = this.actor;
     const element = event.currentTarget;
@@ -177,6 +205,7 @@ export default class OseActorSheet extends ActorSheet {
     actorObject.rollSave(save, { event });
   }
 
+  // eslint-disable-next-line no-underscore-dangle
   async _rollAttack(event) {
     const actorObject = this.actor;
     const element = event.currentTarget;
@@ -187,13 +216,17 @@ export default class OseActorSheet extends ActorSheet {
     });
   }
 
+  // eslint-disable-next-line no-underscore-dangle
   _onSortItem(event, itemData) {
+    // eslint-disable-next-line no-underscore-dangle
     const source = this.actor.items.get(itemData._id);
     const siblings = this.actor.items.filter(
+      // eslint-disable-next-line no-underscore-dangle
       (i) => i.data._id !== source.data._id
     );
     const dropTarget = event.target.closest("[data-item-id]");
     const targetId = dropTarget ? dropTarget.dataset.itemId : null;
+    // eslint-disable-next-line no-underscore-dangle
     const target = siblings.find((s) => s.data._id === targetId);
     if (!target) throw new Error(`Couldn't drop near ${event.target}`);
     const targetData = target?.system;
@@ -214,9 +247,11 @@ export default class OseActorSheet extends ActorSheet {
       ]);
     }
 
+    // eslint-disable-next-line no-underscore-dangle
     super._onSortItem(event, itemData);
   }
 
+  // eslint-disable-next-line no-underscore-dangle
   _onDragStart(event) {
     const li = event.currentTarget;
     let itemIdsArray = [];
@@ -263,53 +298,73 @@ export default class OseActorSheet extends ActorSheet {
     );
   }
 
+  // eslint-disable-next-line no-underscore-dangle, consistent-return
   async _onDropItem(event, data) {
     const item = await Item.implementation.fromDropData(data);
     const itemData = item.toObject();
 
     const exists = !!this.actor.items.get(item.id);
 
-    if (!exists) return this._onDropItemCreate([itemData]);
-
-    const isContainer = this.actor.items.get(item.system.containerId);
-
-    if (isContainer) return this._onContainerItemRemove(item, isContainer);
-
-    const { itemId: targetId } = event.target.closest(".item").dataset;
+    const targetId = event.target.closest(".item")?.dataset?.itemId;
     const targetItem = this.actor.items.get(targetId);
     const targetIsContainer = targetItem?.type === "container";
 
+    const isContainer = this.actor.items.get(item.system.containerId);
+
+    if (!exists && !targetIsContainer)
+      // eslint-disable-next-line no-underscore-dangle
+      return this._onDropItemCreate([itemData]);
+
+    // eslint-disable-next-line no-underscore-dangle
+    if (isContainer) return this._onContainerItemRemove(item, isContainer);
+
+    // eslint-disable-next-line no-underscore-dangle
     if (targetIsContainer) return this._onContainerItemAdd(item, targetItem);
   }
 
+  // eslint-disable-next-line no-underscore-dangle
   async _onContainerItemRemove(item, container) {
-    const newList = container.system.itemIds.filter((s) => s != item.id);
+    const newList = container.system.itemIds.filter((s) => s !== item.id);
     const itemObj = this.object.items.get(item.id);
     await container.update({ system: { itemIds: newList } });
     await itemObj.update({ system: { containerId: "" } });
   }
 
+  // eslint-disable-next-line no-underscore-dangle
   async _onContainerItemAdd(item, target) {
-    const itemData = item.toObject();
-    const container = this.object.items.get(target.id);
-
-    const containerId = container.id;
-    const itemObj = this.object.items.get(item.id);
-    const alreadyExists = container.system.itemIds.find(
-      (i) => i.id === item.id
+    const alreadyExistsInActor = target.parent.items.find(
+      // eslint-disable-next-line no-underscore-dangle
+      (i) => i._id === item._id
     );
-    if (!alreadyExists) {
-      const newList = [...container.system.itemIds, item.id];
-      await container.update({ system: { itemIds: newList } });
-      await itemObj.update({ system: { containerId: container.id } });
+    let latestItem = item;
+    if (!alreadyExistsInActor) {
+      // eslint-disable-next-line no-underscore-dangle
+      const newItem = await this._onDropItemCreate([item.toObject()]);
+      latestItem = newItem.pop();
+    }
+
+    const alreadyExistsInContainer = target.system.itemIds.find(
+      // eslint-disable-next-line no-underscore-dangle
+      (i) => i._id === latestItem._id
+    );
+    if (!alreadyExistsInContainer) {
+      // eslint-disable-next-line no-underscore-dangle
+      const newList = [...target.system.itemIds, latestItem._id];
+      await target.update({ system: { itemIds: newList } });
+      // eslint-disable-next-line no-underscore-dangle
+      await latestItem.update({ system: { containerId: target._id } });
     }
   }
 
-  async _onDropItemCreate(itemData, container = false) {
+  // eslint-disable-next-line no-underscore-dangle, consistent-return
+  async _onDropItemCreate(droppedItem, targetContainer = false) {
     // override to fix hidden items because their original containers don't exist on this actor
-    itemData = Array.isArray(itemData) ? itemData : [itemData];
-    itemData.forEach((item) => {
+    const droppedItemArray = Array.isArray(droppedItem)
+      ? droppedItem
+      : [droppedItem];
+    droppedItemArray.forEach((item) => {
       if (item.system.containerId && item.system.containerId !== "")
+        // eslint-disable-next-line no-param-reassign
         item.system.containerId = "";
       if (
         item.type === "container" &&
@@ -318,24 +373,27 @@ export default class OseActorSheet extends ActorSheet {
         // itemIds was double stringified to fix strange behavior with stringify blanking our Arrays
         const containedItems = JSON.parse(item.system.itemIds);
         containedItems.forEach((containedItem) => {
+          // eslint-disable-next-line no-param-reassign
           containedItem.system.containerId = "";
         });
-        itemData.push(...containedItems);
+        droppedItem.push(...containedItems);
       }
     });
-    if (!container) {
-      return this.actor.createEmbeddedDocuments("Item", itemData);
+    if (!targetContainer) {
+      return this.actor.createEmbeddedDocuments("Item", droppedItem);
     }
 
-    const { itemIds } = container.system;
-    itemIds.push(itemData.id);
-    const item = this.actor.items.get(itemData[0]._id);
-    await item.update({ system: { containerId: container.id } });
-    await container.update({ system: { itemIds } });
+    const { itemIds } = targetContainer.system;
+    itemIds.push(droppedItem.id);
+    // eslint-disable-next-line no-underscore-dangle
+    const item = this.actor.items.get(droppedItem[0]._id);
+    await item.update({ system: { containerId: targetContainer.id } });
+    await targetContainer.update({ system: { itemIds } });
   }
 
   /* -------------------------------------------- */
 
+  // eslint-disable-next-line no-underscore-dangle, class-methods-use-this
   async _chooseItemType(choices = ["weapon", "armor", "shield", "gear"]) {
     const templateData = { types: choices };
     const dlg = await renderTemplate(
@@ -368,20 +426,22 @@ export default class OseActorSheet extends ActorSheet {
     });
   }
 
+  // eslint-disable-next-line no-underscore-dangle, consistent-return
   _createItem(event) {
     event.preventDefault();
     const header = event.currentTarget;
     const { treasure, type } = header.dataset;
-    const createItem = (type, name) => ({
-      name: name || `New ${type.capitalize()}`,
-      type,
+    const createItem = (name, itemType = type) => ({
+      name: name || `New ${itemType.capitalize()}`,
+      type: itemType,
     });
 
     // Getting back to main logic
     if (type === "choice") {
       const choices = header.dataset.choices.split(",");
+      // eslint-disable-next-line promise/catch-or-return, no-underscore-dangle, promise/always-return
       this._chooseItemType(choices).then((dialogInput) => {
-        const itemData = createItem(dialogInput.type, dialogInput.name);
+        const itemData = createItem(dialogInput.name, dialogInput.type);
         this.actor.createEmbeddedDocuments("Item", [itemData], {});
       });
     } else {
@@ -391,25 +451,30 @@ export default class OseActorSheet extends ActorSheet {
     }
   }
 
+  // eslint-disable-next-line no-underscore-dangle, consistent-return
   async _updateItemQuantity(event) {
     event.preventDefault();
+    // eslint-disable-next-line no-underscore-dangle
     const item = this._getItemFromActor(event);
 
     if (event.target.dataset.field === "value") {
       return item.update({
-        "system.quantity.value": parseInt(event.target.value),
+        "system.quantity.value": parseInt(event.target.value, 10),
       });
     }
     if (event.target.dataset.field === "max") {
       return item.update({
-        "system.quantity.max": parseInt(event.target.value),
+        "system.quantity.max": parseInt(event.target.value, 10),
       });
     }
   }
 
   // Override to set resizable initial size
+  // eslint-disable-next-line no-underscore-dangle
   async _renderInner(...args) {
+    // eslint-disable-next-line no-underscore-dangle
     const html = await super._renderInner(...args);
+    // eslint-disable-next-line prefer-destructuring
     this.form = html[0];
 
     // Resize resizable classes
@@ -419,12 +484,16 @@ export default class OseActorSheet extends ActorSheet {
     }
     resizable.each((_, el) => {
       const heightDelta = this.position.height - this.options.height;
-      el.style.height = `${heightDelta + parseInt(el.dataset.baseSize)}px`;
+      // eslint-disable-next-line no-param-reassign
+      el.style.height = `${heightDelta + parseInt(el.dataset.baseSize, 10)}px`;
     });
+    // eslint-disable-next-line consistent-return
     return html;
   }
 
+  // eslint-disable-next-line no-underscore-dangle
   async _onResize(event) {
+    // eslint-disable-next-line no-underscore-dangle
     super._onResize(event);
 
     const html = $(this.form);
@@ -435,7 +504,8 @@ export default class OseActorSheet extends ActorSheet {
     // Resize divs
     resizable.each((_, el) => {
       const heightDelta = this.position.height - this.options.height;
-      el.style.height = `${heightDelta + parseInt(el.dataset.baseSize)}px`;
+      // eslint-disable-next-line no-param-reassign
+      el.style.height = `${heightDelta + parseInt(el.dataset.baseSize, 10)}px`;
     });
     // Resize editors
     const editors = html.find(".editor");
@@ -443,13 +513,15 @@ export default class OseActorSheet extends ActorSheet {
       const container = editor.closest(".resizable-editor");
       if (container) {
         const heightDelta = this.position.height - this.options.height;
+        // eslint-disable-next-line no-param-reassign
         editor.style.height = `${
-          heightDelta + parseInt(container.dataset.editorSize)
+          heightDelta + parseInt(container.dataset.editorSize, 10)
         }px`;
       }
     });
   }
 
+  // eslint-disable-next-line no-underscore-dangle
   _onConfigureActor(event) {
     event.preventDefault();
     new OseEntityTweaks(this.actor, {
@@ -463,7 +535,9 @@ export default class OseActorSheet extends ActorSheet {
    *
    * @override
    */
+  // eslint-disable-next-line no-underscore-dangle
   _getHeaderButtons() {
+    // eslint-disable-next-line no-underscore-dangle
     let buttons = super._getHeaderButtons();
 
     // Token Configuration
@@ -474,9 +548,11 @@ export default class OseActorSheet extends ActorSheet {
           label: game.i18n.localize("OSE.dialog.tweaks"),
           class: "configure-actor",
           icon: "fas fa-code",
+          // eslint-disable-next-line no-underscore-dangle
           onclick: (event) => this._onConfigureActor(event),
         },
-      ].concat(buttons);
+        ...buttons,
+      ];
     }
     return buttons;
   }
@@ -486,10 +562,12 @@ export default class OseActorSheet extends ActorSheet {
 
     // Attributes
     html.find(".saving-throw .attribute-name a").click((event) => {
+      // eslint-disable-next-line no-underscore-dangle
       this._rollSave(event);
     });
 
     html.find(".attack a").click((event) => {
+      // eslint-disable-next-line no-underscore-dangle
       this._rollAttack(event);
     });
 
@@ -499,24 +577,29 @@ export default class OseActorSheet extends ActorSheet {
 
     // Items (Abilities, Inventory and Spells)
     html.find(".item-rollable .item-image").click(async (event) => {
+      // eslint-disable-next-line no-underscore-dangle
       this._rollAbility(event);
     });
 
     html.find(".inventory .item-category-title").click((event) => {
+      // eslint-disable-next-line no-underscore-dangle
       this._toggleItemCategory(event);
     });
     html.find(".inventory .item-category-title input").click((event) => {
       event.stopPropagation();
     });
     html.find(".inventory .category-caret").click((event) => {
+      // eslint-disable-next-line no-underscore-dangle
       this._toggleContainedItems(event);
     });
 
     html.find(".item-name").click((event) => {
+      // eslint-disable-next-line no-underscore-dangle
       this._toggleItemSummary(event);
     });
 
     html.find(".item-controls .item-show").click(async (event) => {
+      // eslint-disable-next-line no-underscore-dangle
       this._displayItemInChat(event);
     });
 
@@ -525,24 +608,29 @@ export default class OseActorSheet extends ActorSheet {
 
     // Item Management
     html.find(".item-create").click((event) => {
+      // eslint-disable-next-line no-underscore-dangle
       this._createItem(event);
     });
 
     html.find(".item-edit").click((event) => {
+      // eslint-disable-next-line no-underscore-dangle
       const item = this._getItemFromActor(event);
       item.sheet.render(true);
     });
 
     html.find(".item-delete").click((event) => {
+      // eslint-disable-next-line no-underscore-dangle
       const item = this._getItemFromActor(event);
 
       if (item?.type !== "container" || !item?.system?.itemIds?.length > 0)
+        // eslint-disable-next-line no-underscore-dangle
         return this._removeItemFromActor(event);
 
-      Dialog.confirm({
+      return Dialog.confirm({
         title: game.i18n.localize("OSE.dialog.deleteContainer"),
         content: game.i18n.localize("OSE.dialog.confirmDeleteContainer"),
         yes: () => {
+          // eslint-disable-next-line no-underscore-dangle
           this._removeItemFromActor(event);
         },
         defaultYes: false,
@@ -552,13 +640,16 @@ export default class OseActorSheet extends ActorSheet {
     html
       .find(".quantity input")
       .click((ev) => ev.target.select())
+      // eslint-disable-next-line no-underscore-dangle
       .change(this._updateItemQuantity.bind(this));
 
     // Consumables
     html.find(".consumable-counter .full-mark").click((event) => {
+      // eslint-disable-next-line no-underscore-dangle
       this._useConsumable(event, true);
     });
     html.find(".consumable-counter .empty-mark").click((event) => {
+      // eslint-disable-next-line no-underscore-dangle
       this._useConsumable(event, false);
     });
 
@@ -566,11 +657,13 @@ export default class OseActorSheet extends ActorSheet {
     html
       .find(".memorize input")
       .click((event) => event.target.select())
+      // eslint-disable-next-line no-underscore-dangle
       .change(this._onSpellChange.bind(this));
 
     html
       .find(".spells .item-reset[data-action='reset-spells']")
       .click((event) => {
+        // eslint-disable-next-line no-underscore-dangle
         this._resetSpells(event);
       });
   }


### PR DESCRIPTION
resolves #310 resolves #265

This bug-fix does a few things:
1. It adds CR(UD) tests for containers in `ActorSheets` as discussed in #265 
2. It add code that actually remove items from a containers `itemIds`
4. It reworks  `ActorSheet._removeItemFromActor` to use Item instead of an Event so it can be tested
5. It fixes  `ActorSheet._onDropItem` and makes it correctly drop items eventhough not dropped onto another item
6. It fixes `ActorSheet._onContainerItemAdd` so that it checks if an item exists in actor, otherwise creates it before moving it to a container (fixes #265)