### PR TITLE
fix: Macros, Actor-sheet, Items, Party

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -312,6 +312,7 @@
   "OSE.warn.moreThanOneItemWithName": "Your controlled Actor {actorName} has more than one Item with name {itemName}. The first matched Item will be chosen.",
   "OSE.warn.macrosOnlyForOwnedItems": "Only Items owned by Actor may be used to create macros.",
   "OSE.warn.macrosNoTokenOwnedInScene": "No controlled token in scene",
+  "OSE.warn.macrosNotAnItem": "Unable to create macro, not an item.",
 
   "OSE.error.macrosOnlyForOwnedItems": "You can only create macro buttons for owned Items",
   "OSE.error.noItemWithName": "Your controlled Actor {actorName} does not have an item named {itemName}.",

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -248,31 +248,31 @@ const config: OseConfig = {
   },
   tag_images: {
     get melee() {
-      return `${OSE.assetsPath}/melee.png`;
+      return `${CONFIG.OSE.assetsPath}/melee.png`;
     },
     get missile() {
       return `fa-bow-arrow`;
     },
     get slow() {
-      return `${OSE.assetsPath}/slow.png`;
+      return `${CONFIG.OSE.assetsPath}/slow.png`;
     },
     get twohanded() {
-      return `${OSE.assetsPath}/twohanded.png`;
+      return `${CONFIG.OSE.assetsPath}/twohanded.png`;
     },
     get blunt() {
-      return `${OSE.assetsPath}/blunt.png`;
+      return `${CONFIG.OSE.assetsPath}/blunt.png`;
     },
     get brace() {
-      return `${OSE.assetsPath}/brace.png`;
+      return `${CONFIG.OSE.assetsPath}/brace.png`;
     },
     get splash() {
-      return `${OSE.assetsPath}/splash.png`;
+      return `${CONFIG.OSE.assetsPath}/splash.png`;
     },
     get reload() {
-      return `${OSE.assetsPath}/reload.png`;
+      return `${CONFIG.OSE.assetsPath}/reload.png`;
     },
     get charge() {
-      return `${OSE.assetsPath}/charge.png`;
+      return `${CONFIG.OSE.assetsPath}/charge.png`;
     },
   },
   monster_saves: {

--- a/src/module/dialog/entity-tweaks.js
+++ b/src/module/dialog/entity-tweaks.js
@@ -7,6 +7,7 @@ export default class OseEntityTweaks extends FormApplication {
   static get defaultOptions() {
     const options = super.defaultOptions;
     options.id = "sheet-tweaks";
+    options.classes = ["sheet-tweaks"];
     options.template = `${OSE.systemPath()}/templates/actors/dialogs/tweaks-dialog.html`;
     options.width = 380;
     return options;

--- a/src/module/helpers-dice.js
+++ b/src/module/helpers-dice.js
@@ -158,7 +158,7 @@ const OseDice = {
       return false;
     }
     if (roll.total >= 20 || roll.terms[0].results[0] === 20) {
-      return true, -3;
+      return true;
     }
     if (roll.total + ac >= thac0) {
       return true;
@@ -182,8 +182,8 @@ const OseDice = {
 
     if (game.settings.get(game.system.id, "ascendingAC")) {
       if (
-        (roll.terms[0] != 20 && roll.total < targetAac) ||
-        roll.terms[0] === 1
+        (roll.terms[0].total !== 20 && roll.total < targetAac) ||
+        roll.terms[0].total === 1
       ) {
         result.details = game.i18n.format(
           "OSE.messages.AttackAscendingFailure",
@@ -191,6 +191,7 @@ const OseDice = {
             bonus: result.target,
           }
         );
+        result.isFailure = true;
         return result;
       }
       result.details = game.i18n.format("OSE.messages.AttackAscendingSuccess", {
@@ -202,6 +203,7 @@ const OseDice = {
         result.details = game.i18n.format("OSE.messages.AttackFailure", {
           bonus: result.target,
         });
+        result.isFailure = true;
         return result;
       }
       result.isSuccess = true;

--- a/src/module/helpers-macros.js
+++ b/src/module/helpers-macros.js
@@ -11,10 +11,16 @@
  *
  * @param {object} data - The dropped data
  * @param {number} slot - The hotbar slot to use
- * @returns {Promise}
+ * @returns {Promise} - Promise of assigned macro or a notification
  */
 export async function createOseMacro(data, slot) {
-  if (data.type !== "Item") return;
+  if (data.type === "Macro") {
+    return game.user.assignHotbarMacro(await fromUuid(data.uuid), slot);
+  }
+  if (data.type !== "Item")
+    return ui.notifications.warn(
+      game.i18n.localize("OSE.warn.macrosNotAnItem")
+    );
   if (data.uuid.indexOf("Item.") <= 0)
     return ui.notifications.warn(
       game.i18n.localize("OSE.warn.macrosOnlyForOwnedItems")
@@ -35,8 +41,7 @@ export async function createOseMacro(data, slot) {
       flags: { "ose.itemMacro": true },
     });
   }
-  game.user.assignHotbarMacro(macro, slot);
-  return false;
+  return game.user.assignHotbarMacro(macro, slot);
 }
 
 /* -------------------------------------------- */
@@ -45,8 +50,8 @@ export async function createOseMacro(data, slot) {
  * Create a Macro from an Item drop.
  * Get an existing item macro if one exists, otherwise create a new one.
  *
- * @param {string} itemName
- * @returns {Promise}
+ * @param {string} itemName - Name of item to roll
+ * @returns {Promise} - Promise of item roll or notification
  */
 export function rollItemMacro(itemName) {
   const speaker = ChatMessage.getSpeaker();

--- a/src/module/helpers-treasure.js
+++ b/src/module/helpers-treasure.js
@@ -63,7 +63,7 @@ export const augmentTable = (table, html) => {
 async function drawTreasure(table, data) {
   const percent = async (chance) => {
     const roll = new Roll("1d100");
-    await roll.evaluate();
+    await roll.evaluate({ async: true });
     return roll.total <= chance;
   };
   data.treasure = {};

--- a/src/module/helpers-treasure.js
+++ b/src/module/helpers-treasure.js
@@ -85,7 +85,7 @@ function drawTreasure(table, data) {
       }
     });
   } else {
-    const { results } = table.evaluate({ async: false });
+    const { results } = table.roll({ async: true });
     results.forEach((s) => {
       const text = TextEditor.enrichHTML(table._getResultChatText(s), {
         async: false,

--- a/src/module/helpers-treasure.js
+++ b/src/module/helpers-treasure.js
@@ -60,37 +60,34 @@ export const augmentTable = (table, html) => {
  * @param table
  * @param data
  */
-function drawTreasure(table, data) {
-  const percent = (chance) => {
+async function drawTreasure(table, data) {
+  const percent = async (chance) => {
     const roll = new Roll("1d100");
-    roll.evaluate({ async: false });
+    await roll.evaluate();
     return roll.total <= chance;
   };
   data.treasure = {};
   if (table.getFlag(game.system.id, "treasure")) {
-    table.results.forEach((r) => {
-      if (percent(r.data.weight)) {
+    table.results.forEach(async (r) => {
+      if (percent(r.weight)) {
         const text = r.getChatText(r);
         data.treasure[r.id] = {
-          img: r.data.img,
+          img: r.img,
           text: TextEditor.enrichHTML(text, { async: false }),
         };
         if (
-          r.data.type === CONST.TABLE_RESULT_TYPES.DOCUMENT &&
-          r.data.collection === "RollTable"
+          r.type === CONST.TABLE_RESULT_TYPES.DOCUMENT &&
+          r.collection === "RollTable"
         ) {
-          const embeddedTable = game.tables.get(r.data.resultId);
-          drawTreasure(embeddedTable, data.treasure[r.id]);
+          const embeddedTable = game.tables.get(r.resultId);
+          await drawTreasure(embeddedTable, data.treasure[r.id]);
         }
       }
     });
   } else {
-    const { results } = table.roll({ async: true });
+    const { results } = await table.roll();
     results.forEach((s) => {
-      const text = TextEditor.enrichHTML(table._getResultChatText(s), {
-        async: false,
-      });
-      data.treasure[s.id] = { img: s.data.img, text };
+      data.treasure[s.id] = { img: s.img, text: s.text };
     });
   }
   return data;
@@ -103,7 +100,7 @@ function drawTreasure(table, data) {
  */
 async function rollTreasure(table, options = {}) {
   // Draw treasure
-  const data = drawTreasure(table, {});
+  const data = await drawTreasure(table, {});
   const templateData = {
     treasure: data.treasure,
     table,

--- a/src/module/item/data-model-container.js
+++ b/src/module/item/data-model-container.js
@@ -29,11 +29,14 @@ export default class OseDataModelContainer extends foundry.abstract.DataModel {
   }
 
   get totalWeight() {
-    return this.contents.reduce(
-      (acc, { system: { weight, quantity } }) =>
-        acc + weight * (quantity?.value || 1),
-      0
-    );
+    if (this.content) {
+      return this.contents.reduce(
+        (acc, { system: { weight, quantity } }) =>
+          acc + weight * (quantity?.value || 1),
+        0
+      );
+    }
+    return 0;
   }
 
   get manualTags() {

--- a/src/module/party/party-sheet.js
+++ b/src/module/party/party-sheet.js
@@ -119,11 +119,11 @@ export default class OsePartySheet extends FormApplication {
 
   _recursiveAddFolder(folder) {
     folder.contents.forEach((actor) => this._addActorToParty(actor));
-    folder.children.forEach((folder) => this._recursiveAddFolder(folder));
+    folder.children.forEach((folder) => this._recursiveAddFolder(folder.folder));
   }
 
   async _onDropFolder(event, data) {
-    if (data.documentName !== "Actor") {
+    if (data.documentName !== "Folder") {
       return;
     }
 


### PR DESCRIPTION
- Fix: missing localization for when not using an item to create a macro.
- Fix: issues where user was unable to delete containers, resolves #310
- Fix: drag and drop behaviour when dragging files into containers, resolves #265
- Fix: various bugs with containers.
- Fix: bugs introduces due to above fixes where items were created using the wrong name
- Fix: bug where `tag_images` in config didn't return correct paths due
- Fix: bug where class was missing from entity tweaks dialog
- Enhancement: `drawTreasure` is now asynchronuos as the synchronous version is deprecated
- Fix: Fixed deprecated behavior in treasure helpers where `data` was still used.
- Fix: Empty containers now return 0 weight correctly.
- Fix: Made `spendSpell` asynchronous
- Fix: Bug where recursive folders with actor in didn't add properly to party sheet.

Will keep in draft until #334 & #335 are merged.