### PR TITLE
fix(dice): Dice rolling fixes for 1.8.x

### DIFF
--- a/src/module/__tests__/helpers-dice.test.ts
+++ b/src/module/__tests__/helpers-dice.test.ts
@@ -430,9 +430,6 @@ export default ({
       rollData.data.roll.dmg = [];
       await OseDice.sendAttackRoll(rollData);
       await waitForInput();
-      await waitForInput();
-      await waitForInput();
-      await waitForInput();
       const notification = ui.notifications?.queue.pop();
       expect(ui.notifications?.queue.length).equal(0);
       expect(notification?.message).equal(
@@ -453,71 +450,6 @@ export default ({
         ".damage-roll .dice-formula"
       )?.innerHTML;
       expect(damageDiceResult).equal("1d6");
-    });
-    it("Can roll with single part and multiple dmg dice", async () => {
-      const rollData = createMockAttackData();
-      rollData.data.roll.dmg = ["1d6", "1d100"];
-      await OseDice.sendAttackRoll(rollData);
-      await waitForInput();
-      await waitForInput();
-      await waitForInput();
-      await waitForInput();
-      const attackDiceResult =
-        document.querySelector(".dice-formula")?.innerHTML;
-      expect(attackDiceResult).equal("1d20 + 0 + 0 + 0");
-      const damageDiceResult = document.querySelector(
-        ".damage-roll .dice-formula"
-      )?.innerHTML;
-      expect(damageDiceResult).equal("1d6 + 1d100");
-    });
-    it("Can roll with multiple parts and single dmg die", async () => {
-      const rollData = createMockAttackData();
-      rollData.parts = ["1d20", "1d10", "30"];
-      await OseDice.sendAttackRoll(rollData);
-      await waitForInput();
-      await waitForInput();
-      await waitForInput();
-      await waitForInput();
-      const attackDiceResult =
-        document.querySelector(".dice-formula")?.innerHTML;
-      expect(attackDiceResult).equal("1d20 + 1d10 + 30");
-      const damageDiceResult = document.querySelector(
-        ".damage-roll .dice-formula"
-      )?.innerHTML;
-      expect(damageDiceResult).equal("1d6");
-    });
-    it("Can roll with multiple parts and single dmg die", async () => {
-      const rollData = createMockAttackData();
-      rollData.parts = ["1d20", "1d10", "300"];
-      await OseDice.sendAttackRoll(rollData);
-      await waitForInput();
-      await waitForInput();
-      await waitForInput();
-      await waitForInput();
-      const attackDiceResult =
-        document.querySelector(".dice-formula")?.innerHTML;
-      expect(attackDiceResult).equal("1d20 + 1d10 + 300");
-      const damageDiceResult = document.querySelector(
-        ".damage-roll .dice-formula"
-      )?.innerHTML;
-      expect(damageDiceResult).equal("1d6");
-    });
-    it("Can roll with multiple parts and multiple dmg dice", async () => {
-      const rollData = createMockAttackData();
-      rollData.parts = ["1d20", "1d10", "30"];
-      rollData.data.roll.dmg = ["1d6", "1d100"];
-      await OseDice.sendAttackRoll(rollData);
-      await waitForInput();
-      await waitForInput();
-      await waitForInput();
-      await waitForInput();
-      const attackDiceResult =
-        document.querySelector(".dice-formula")?.innerHTML;
-      expect(attackDiceResult).equal("1d20 + 1d10 + 30");
-      const damageDiceResult = document.querySelector(
-        ".damage-roll .dice-formula"
-      )?.innerHTML;
-      expect(damageDiceResult).equal("1d6 + 1d100");
     });
     afterEach(async () => {
       await trashChat();

--- a/src/module/__tests__/helpers-dice.test.ts
+++ b/src/module/__tests__/helpers-dice.test.ts
@@ -11,27 +11,9 @@ export const options = {
   displayName: "Helpers: Dice",
 };
 
-const createMockData = (type: string, target: number, thac0: number = 0) => ({
-  roll: { type, target, thac0 },
-});
-
-const createMockRoll = (target: number, results: Array<number> = [target]) => ({
-  terms: [{ total: target, results }],
+const createMockRoll = (target: number, result: number = target) => ({
+  terms: [{ results: [{ result }] }],
   total: target,
-});
-
-const createMockAttackData = () => ({
-  parts: ["20"],
-  data: {
-    roll: {
-      blindroll: false,
-      dmg: ["1d6"],
-      thac0: 15,
-      target: {
-        actor: { system: { ac: { value: 0 }, aac: { value: 9 } } },
-      },
-    },
-  },
 });
 
 export default ({
@@ -93,6 +75,14 @@ export default ({
     });
   });
   describe("digestResult(data, roll)", () => {
+    // eslint-disable-next-line unicorn/consistent-function-scoping
+    const createMockData = (
+      type: string,
+      target: number,
+      thac0: number = 0
+    ) => ({
+      roll: { type, target, thac0 },
+    });
     describe("result type", () => {
       const data = createMockData("result", 10);
       it("Successful roll hitting target", () => {
@@ -212,36 +202,76 @@ export default ({
       });
     });
   });
-  describe("attackIsSuccess(roll, thac0, ac)", () => {
-    it("Natural 1 always fails", () => {
-      const rollTargetOne = createMockRoll(1, [1]);
-      expect(OseDice.attackIsSuccess(rollTargetOne, 21, 0)).equal(false);
-      const rollTargetTwenty = createMockRoll(20, [1]);
-      expect(OseDice.attackIsSuccess(rollTargetTwenty, 21, 0)).equal(false);
+  describe("attackIsSuccess(roll, target, bonus)", () => {
+    describe("Ascending AC", () => {
+      before(async () => {
+        await game.settings.set(game.system.id, "ascendingAC", true);
+      });
+      it("Natural 1 always fails", () => {
+        const rollTargetOne = createMockRoll(1, 1);
+        expect(OseDice.attackIsSuccess(rollTargetOne, 100, 0)).equal(false);
+        const rollTargetTwenty = createMockRoll(20, 1);
+        expect(OseDice.attackIsSuccess(rollTargetTwenty, 100, 0)).equal(false);
+      });
+      it("Natural 20 always succeeds", () => {
+        const rollTargetOne = createMockRoll(1, 20);
+        expect(OseDice.attackIsSuccess(rollTargetOne, 0, 100)).equal(true);
+        const rollTargetTwenty = createMockRoll(20, 20);
+        expect(OseDice.attackIsSuccess(rollTargetTwenty, 0, 100)).equal(true);
+      });
+      it("Roll + bonus equal target is successful", () => {
+        const roll = createMockRoll(10);
+        const target = 20;
+        const bonus = 10;
+        expect(OseDice.attackIsSuccess(roll, target, bonus)).equal(true);
+      });
+      it("Roll + bonus above target is successful", () => {
+        const roll = createMockRoll(10);
+        const target = 19;
+        const bonus = 10;
+        expect(OseDice.attackIsSuccess(roll, target, bonus)).equal(true);
+      });
+      it("Roll + bnous under target is unsuccessful", () => {
+        const roll = createMockRoll(10);
+        const target = 21;
+        const bonus = 10;
+        expect(OseDice.attackIsSuccess(roll, target, bonus)).equal(false);
+      });
     });
-    it("Natural 20 always succeeds", () => {
-      const rollTargetOne = createMockRoll(1, [20]);
-      expect(OseDice.attackIsSuccess(rollTargetOne, 0, 21)).equal(true);
-      const rollTargetTwenty = createMockRoll(20, [20]);
-      expect(OseDice.attackIsSuccess(rollTargetTwenty, 0, 21)).equal(true);
-    });
-    it("Roll + ac equal thac0 is successful", () => {
-      const roll = createMockRoll(10);
-      const thac0 = 20;
-      const ac = 10;
-      expect(OseDice.attackIsSuccess(roll, thac0, ac)).equal(true);
-    });
-    it("Roll + ac above thac0 is successful", () => {
-      const roll = createMockRoll(10);
-      const thac0 = 19;
-      const ac = 10;
-      expect(OseDice.attackIsSuccess(roll, thac0, ac)).equal(true);
-    });
-    it("Roll + ac under thac0 is unsuccessful", () => {
-      const roll = createMockRoll(10);
-      const thac0 = 21;
-      const ac = 10;
-      expect(OseDice.attackIsSuccess(roll, thac0, ac)).equal(false);
+    describe("Descending AC", () => {
+      before(async () => {
+        await game.settings.set(game.system.id, "ascendingAC", false);
+      });
+      it("Natural 1 always fails", () => {
+        const rollTargetOne = createMockRoll(1, 1);
+        expect(OseDice.attackIsSuccess(rollTargetOne, 100, 0)).equal(false);
+        const rollTargetTwenty = createMockRoll(20, 1);
+        expect(OseDice.attackIsSuccess(rollTargetTwenty, 100, 0)).equal(false);
+      });
+      it("Natural 20 always succeeds", () => {
+        const rollTargetOne = createMockRoll(1, 20);
+        expect(OseDice.attackIsSuccess(rollTargetOne, 0, 100)).equal(true);
+        const rollTargetTwenty = createMockRoll(20, 20);
+        expect(OseDice.attackIsSuccess(rollTargetTwenty, 0, 100)).equal(true);
+      });
+      it("Roll + ac equal thac0 is successful", () => {
+        const roll = createMockRoll(10);
+        const thac0 = 20;
+        const ac = 10;
+        expect(OseDice.attackIsSuccess(roll, thac0, ac)).equal(true);
+      });
+      it("Roll + ac above thac0 is successful", () => {
+        const roll = createMockRoll(10);
+        const thac0 = 19;
+        const ac = 10;
+        expect(OseDice.attackIsSuccess(roll, thac0, ac)).equal(true);
+      });
+      it("Roll + ac under thac0 is unsuccessful", () => {
+        const roll = createMockRoll(10);
+        const thac0 = 21;
+        const ac = 10;
+        expect(OseDice.attackIsSuccess(roll, thac0, ac)).equal(false);
+      });
     });
   });
   describe("digestAttackResult(data, roll)", () => {
@@ -259,17 +289,19 @@ export default ({
       },
     };
     describe("Ascending AC", () => {
-      it("Natural 1 terms is unsuccesful", async () => {
+      before(async () => {
         await game.settings.set(game.system.id, "ascendingAC", true);
+      });
+      it("Natural 1 terms is unsuccesful", async () => {
         expect(game.settings.get(game.system.id, "ascendingAC")).equal(true);
-        const rollTargetOne = createMockRoll(1, [1]);
+        const rollTargetOne = createMockRoll(1, 1);
         expect(OseDice.digestAttackResult(data, rollTargetOne).isSuccess).equal(
           false
         );
         expect(OseDice.digestAttackResult(data, rollTargetOne).isFailure).equal(
           true
         );
-        const rollTargetTwenty = createMockRoll(20, [1]);
+        const rollTargetTwenty = createMockRoll(20, 1);
         expect(
           OseDice.digestAttackResult(data, rollTargetTwenty).isSuccess
         ).equal(false);
@@ -278,29 +310,38 @@ export default ({
         ).equal(true);
       });
       it("Lower than target AC is unsuccesful", () => {
-        const roll = createMockRoll(8);
+        const attackBonus = 19 - data.roll.thac0;
+        const roll = createMockRoll(
+          data.roll.target.actor.system.aac.value - attackBonus - 1
+        );
         expect(OseDice.digestAttackResult(data, roll).isSuccess).equal(false);
         expect(OseDice.digestAttackResult(data, roll).isFailure).equal(true);
       });
       it("Equal than target AC is succesful", () => {
-        const roll = createMockRoll(9);
+        const attackBonus = 19 - data.roll.thac0;
+        const roll = createMockRoll(
+          data.roll.target.actor.system.aac.value - attackBonus
+        );
         expect(OseDice.digestAttackResult(data, roll).isSuccess).equal(true);
         expect(OseDice.digestAttackResult(data, roll).isFailure).equal(false);
       });
       it("Higher than target AC is succesful", () => {
-        const roll = createMockRoll(11);
+        const attackBonus = 19 - data.roll.thac0;
+        const roll = createMockRoll(
+          data.roll.target.actor.system.aac.value - attackBonus + 1
+        );
         expect(OseDice.digestAttackResult(data, roll).isSuccess).equal(true);
         expect(OseDice.digestAttackResult(data, roll).isFailure).equal(false);
       });
       it("Natural 20 is succesful", () => {
-        const rollTargetOne = createMockRoll(1, [20]);
+        const rollTargetOne = createMockRoll(1, 20);
         expect(OseDice.digestAttackResult(data, rollTargetOne).isSuccess).equal(
           true
         );
         expect(OseDice.digestAttackResult(data, rollTargetOne).isFailure).equal(
           false
         );
-        const rollTargetTwenty = createMockRoll(20, [20]);
+        const rollTargetTwenty = createMockRoll(20, 20);
         expect(
           OseDice.digestAttackResult(data, rollTargetTwenty).isSuccess
         ).equal(true);
@@ -310,17 +351,19 @@ export default ({
       });
     });
     describe("Descending AC, ac=0", () => {
-      it("Natural 1 terms is unsuccesful", async () => {
+      before(async () => {
         await game.settings.set(game.system.id, "ascendingAC", false);
+      });
+      it("Natural 1 terms is unsuccesful", async () => {
         expect(game.settings.get(game.system.id, "ascendingAC")).equal(false);
-        const rollTargetOne = createMockRoll(1, [1]);
+        const rollTargetOne = createMockRoll(1, 1);
         expect(OseDice.digestAttackResult(data, rollTargetOne).isSuccess).equal(
           false
         );
         expect(OseDice.digestAttackResult(data, rollTargetOne).isFailure).equal(
           true
         );
-        const rollTargetTwenty = createMockRoll(20, [1]);
+        const rollTargetTwenty = createMockRoll(20, 1);
         expect(
           OseDice.digestAttackResult(data, rollTargetTwenty).isSuccess
         ).equal(false);
@@ -329,29 +372,29 @@ export default ({
         ).equal(true);
       });
       it("Lower than thac0 is unsuccesful", () => {
-        const roll = createMockRoll(14);
+        const roll = createMockRoll(data.roll.thac0 - 1);
         expect(OseDice.digestAttackResult(data, roll).isSuccess).equal(false);
         expect(OseDice.digestAttackResult(data, roll).isFailure).equal(true);
       });
       it("Equal to thac0 is succesful", () => {
-        const roll = createMockRoll(15);
+        const roll = createMockRoll(data.roll.thac0);
         expect(OseDice.digestAttackResult(data, roll).isSuccess).equal(true);
         expect(OseDice.digestAttackResult(data, roll).isFailure).equal(false);
       });
       it("Higher than thac0 is succesful", () => {
-        const roll = createMockRoll(16);
+        const roll = createMockRoll(data.roll.thac0 + 1);
         expect(OseDice.digestAttackResult(data, roll).isSuccess).equal(true);
         expect(OseDice.digestAttackResult(data, roll).isFailure).equal(false);
       });
       it("Natural 20 is succesful", () => {
-        const rollTargetOne = createMockRoll(1, [20]);
+        const rollTargetOne = createMockRoll(1, 20);
         expect(OseDice.digestAttackResult(data, rollTargetOne).isSuccess).equal(
           true
         );
         expect(OseDice.digestAttackResult(data, rollTargetOne).isFailure).equal(
           false
         );
-        const rollTargetTwenty = createMockRoll(20, [20]);
+        const rollTargetTwenty = createMockRoll(20, 20);
         expect(
           OseDice.digestAttackResult(data, rollTargetTwenty).isSuccess
         ).equal(true);
@@ -362,6 +405,21 @@ export default ({
     });
   });
   describe("sendAttackRoll(parts, data, flags, title, flavor, speaker, form)", () => {
+    // eslint-disable-next-line unicorn/consistent-function-scoping
+    const createMockAttackData = () => ({
+      parts: ["1d20", "0", "0", "0"],
+      data: {
+        roll: {
+          type: "melee",
+          dmg: ["1d6"],
+          thac0: 15,
+          target: {
+            actor: { system: { ac: { value: 0 }, aac: { value: 9 } } },
+          },
+        },
+      },
+    });
+
     before(async () => {
       await trashChat();
       await game.settings.set(game.system.id, "ascendingAC", true);
@@ -371,6 +429,8 @@ export default ({
       const rollData = createMockAttackData();
       rollData.data.roll.dmg = [];
       await OseDice.sendAttackRoll(rollData);
+      await waitForInput();
+      await waitForInput();
       await waitForInput();
       await waitForInput();
       const notification = ui.notifications?.queue.pop();
@@ -384,14 +444,14 @@ export default ({
       await OseDice.sendAttackRoll(rollData);
       await waitForInput();
       await waitForInput();
-      const attackResult = document.querySelector(".roll-result b").innerHTML;
-      expect(attackResult).equal("Hits AC 20!");
+      await waitForInput();
+      await waitForInput();
       const attackDiceResult =
-        document.querySelector(".dice-formula").innerHTML;
-      expect(attackDiceResult).equal("20");
+        document.querySelector(".dice-formula")?.innerHTML;
+      expect(attackDiceResult).equal("1d20 + 0 + 0 + 0");
       const damageDiceResult = document.querySelector(
         ".damage-roll .dice-formula"
-      ).innerHTML;
+      )?.innerHTML;
       expect(damageDiceResult).equal("1d6");
     });
     it("Can roll with single part and multiple dmg dice", async () => {
@@ -400,14 +460,14 @@ export default ({
       await OseDice.sendAttackRoll(rollData);
       await waitForInput();
       await waitForInput();
-      const attackResult = document.querySelector(".roll-result b").innerHTML;
-      expect(attackResult).equal("Hits AC 20!");
+      await waitForInput();
+      await waitForInput();
       const attackDiceResult =
-        document.querySelector(".dice-formula").innerHTML;
-      expect(attackDiceResult).equal("20");
+        document.querySelector(".dice-formula")?.innerHTML;
+      expect(attackDiceResult).equal("1d20 + 0 + 0 + 0");
       const damageDiceResult = document.querySelector(
         ".damage-roll .dice-formula"
-      ).innerHTML;
+      )?.innerHTML;
       expect(damageDiceResult).equal("1d6 + 1d100");
     });
     it("Can roll with multiple parts and single dmg die", async () => {
@@ -416,14 +476,14 @@ export default ({
       await OseDice.sendAttackRoll(rollData);
       await waitForInput();
       await waitForInput();
-      const attackResult = document.querySelector(".roll-result b").innerHTML;
-      expect(attackResult).contain("Hits AC");
+      await waitForInput();
+      await waitForInput();
       const attackDiceResult =
-        document.querySelector(".dice-formula").innerHTML;
+        document.querySelector(".dice-formula")?.innerHTML;
       expect(attackDiceResult).equal("1d20 + 1d10 + 30");
       const damageDiceResult = document.querySelector(
         ".damage-roll .dice-formula"
-      ).innerHTML;
+      )?.innerHTML;
       expect(damageDiceResult).equal("1d6");
     });
     it("Can roll with multiple parts and single dmg die", async () => {
@@ -432,14 +492,14 @@ export default ({
       await OseDice.sendAttackRoll(rollData);
       await waitForInput();
       await waitForInput();
-      const attackResult = document.querySelector(".roll-result b").innerHTML;
-      expect(attackResult).contain("Hits AC");
+      await waitForInput();
+      await waitForInput();
       const attackDiceResult =
-        document.querySelector(".dice-formula").innerHTML;
+        document.querySelector(".dice-formula")?.innerHTML;
       expect(attackDiceResult).equal("1d20 + 1d10 + 300");
       const damageDiceResult = document.querySelector(
         ".damage-roll .dice-formula"
-      ).innerHTML;
+      )?.innerHTML;
       expect(damageDiceResult).equal("1d6");
     });
     it("Can roll with multiple parts and multiple dmg dice", async () => {
@@ -449,14 +509,14 @@ export default ({
       await OseDice.sendAttackRoll(rollData);
       await waitForInput();
       await waitForInput();
-      const attackResult = document.querySelector(".roll-result b").innerHTML;
-      expect(attackResult).contain("Hits AC");
+      await waitForInput();
+      await waitForInput();
       const attackDiceResult =
-        document.querySelector(".dice-formula").innerHTML;
+        document.querySelector(".dice-formula")?.innerHTML;
       expect(attackDiceResult).equal("1d20 + 1d10 + 30");
       const damageDiceResult = document.querySelector(
         ".damage-roll .dice-formula"
-      ).innerHTML;
+      )?.innerHTML;
       expect(damageDiceResult).equal("1d6 + 1d100");
     });
     afterEach(async () => {

--- a/src/module/__tests__/helpers-dice.test.ts
+++ b/src/module/__tests__/helpers-dice.test.ts
@@ -318,7 +318,7 @@ export default ({
           OseDice.digestAttackResult(data, rollTargetTwenty).isFailure
         ).equal(true);
       });
-      it("Low total but not 1 is successful Issue#340", () => {
+      it("Attack rolls with a modified result of 1 are allowed to succeeed if hits target AC. Issue#340", () => {
         const attackBonus = -1;
         const targetData = {
           roll: {
@@ -361,7 +361,7 @@ export default ({
         expect(OseDice.digestAttackResult(data, roll).isSuccess).equal(true);
         expect(OseDice.digestAttackResult(data, roll).isFailure).equal(false);
       });
-      it("High total but not 20 is successful Issue#340", () => {
+      it("Attack rolls with a modified result of 20 are allowed to fail if doesn't hit target AC. Issue#340", () => {
         const attackBonus = 1;
         const targetData = {
           roll: {

--- a/src/module/helpers-dice.js
+++ b/src/module/helpers-dice.js
@@ -153,7 +153,15 @@ const OseDice = {
     return result;
   },
 
-  attackIsSuccess(roll, target, bonus) {
+  /**
+   * Evaluates if a roll is successful for both THAC0 and Ascending AC
+   *
+   * @param {object} roll - Evaluated roll data from a Roll
+   * @param {number} thac0 - THAC0 value, or Hit Target when AscendingAC
+   * @param {number} ac - AC Value, or Attack Bonus when AscendingAC
+   * @returns {boolean} - Did the attack succeed?
+   */
+  attackIsSuccess(roll, thac0, ac) {
     // Natural 1
     if (roll.terms[0].results[0].result === 1) {
       return false;
@@ -162,7 +170,7 @@ const OseDice = {
     if (roll.terms[0].results[0].result === 20) {
       return true;
     }
-    return roll.total + bonus >= target;
+    return roll.total + ac >= thac0;
   },
 
   digestAttackResult(data, roll) {
@@ -199,6 +207,7 @@ const OseDice = {
         result.isFailure = true;
       }
     } else if (this.attackIsSuccess(roll, result.target, targetAc)) {
+      // Answer is bounded betweewn AC -3 and 9 (unarmored) and is shown in chat card
       const value = Math.clamped(result.target - roll.total, -3, 9);
       result.details = game.i18n.format("OSE.messages.AttackSuccess", {
         result: value,

--- a/src/module/helpers-dice.js
+++ b/src/module/helpers-dice.js
@@ -202,8 +202,8 @@ const OseDice = {
     result.target = data.roll.thac0;
     const targetActorData = data.roll.target?.actor?.system || null;
 
-    const targetAc = data.roll.target ? targetActorData.ac.value : 9;
-    const targetAac = data.roll.target ? targetActorData.aac.value : 10;
+    const targetAc = data.roll.target ? targetActorData.ac.value : 20;
+    const targetAac = data.roll.target ? targetActorData.aac.value : -20;
     result.victim = data.roll.target ? data.roll.target.name : null;
 
     if (game.settings.get(game.system.id, "ascendingAC")) {

--- a/src/module/helpers-dice.js
+++ b/src/module/helpers-dice.js
@@ -107,7 +107,7 @@ const OseDice = {
         } else {
           result.isFailure = true;
         }
-        
+
         break;
       }
 

--- a/src/module/helpers-dice.js
+++ b/src/module/helpers-dice.js
@@ -82,7 +82,15 @@ const OseDice = {
     });
   },
 
+  /**
+   * Digesting results depending on type of roll
+   *
+   * @param {object} data - Contains roll data, including what type of check
+   * @param {object} roll - Evaluated Roll returned object
+   * @returns {object} - Object containing the evaluated data // @todo DigestResult
+   */
   digestResult(data, roll) {
+    // @todo: Extract this to a DigestResult type/interface
     const result = {
       isSuccess: false,
       isFailure: false,
@@ -91,6 +99,7 @@ const OseDice = {
     };
 
     const die = roll.terms[0].results[0].result;
+    // eslint-disable-next-line default-case
     switch (data.roll.type) {
       case "result": {
         if (roll.total === result.target) {
@@ -98,7 +107,7 @@ const OseDice = {
         } else {
           result.isFailure = true;
         }
-
+        
         break;
       }
 
@@ -173,7 +182,17 @@ const OseDice = {
     return roll.total + ac >= thac0;
   },
 
+  /**
+   * Digest the results of a target to reach, and an evaluated roll
+   * to evaluate if it does hit or not. The function adds information
+   * for generating chat card data too.
+   *
+   * @param {object} data - Data with at least roll target data
+   * @param {object} roll - Evaluation result from a Roll
+   * @returns {object} - DigestResult
+   */
   digestAttackResult(data, roll) {
+    // @todo: Extract this to a DigestResult type/interface
     const result = {
       isSuccess: false,
       isFailure: false,
@@ -223,6 +242,25 @@ const OseDice = {
     return result;
   },
 
+  // eslint-disable-next-line jsdoc/require-param
+  /**
+   * Puts together the information needed to roll a Roll and the
+   * expectations on hitting a target. Also creates the chat card
+   * containing the infromation about the evaluated roll.
+   *
+   * @param {object} param0 - Object to evaluate
+   * @param {Array<String || number>} param0.parts - Roll parts (e.g. ["1d20", "3", "0", "0"])
+   * @param {object} param0.data - Object containing target data
+   * @param {object} param0.data.roll - Roll target data
+   * @param {Array<String || number|} param0.data.roll.dmg - Roll parts for damage roll if hit
+   * @param {Actor | null} param0.data.target - Target data for the intended hit target
+   * @param {object} param0.flags -Not used directly in function, but may be passed on
+   * @param {string} param0.title - Modified in RollSave() if magic save required
+   * @param {string} param0.flavor - Not used directly in function
+   * @param {object} param0.speaker- Speaker data for the chat card
+   * @param {object} param0.form - Data from the Dialog Form that generates data for the function
+   * @returns {Promise || Void} - Either not returning anything, or a Promise for rendering a Chat Card
+   */
   async sendAttackRoll({
     parts = [],
     data = {},

--- a/src/module/helpers-dice.js
+++ b/src/module/helpers-dice.js
@@ -242,7 +242,6 @@ const OseDice = {
     return result;
   },
 
-  // eslint-disable-next-line jsdoc/require-param
   /**
    * Puts together the information needed to roll a Roll and the
    * expectations on hitting a target. Also creates the chat card
@@ -257,7 +256,7 @@ const OseDice = {
    * @param {object} param0.flags -Not used directly in function, but may be passed on
    * @param {string} param0.title - Modified in RollSave() if magic save required
    * @param {string} param0.flavor - Not used directly in function
-   * @param {object} param0.speaker- Speaker data for the chat card
+   * @param {object} param0.speaker - Speaker data for the chat card
    * @param {object} param0.form - Data from the Dialog Form that generates data for the function
    * @returns {Promise || Void} - Either not returning anything, or a Promise for rendering a Chat Card
    */


### PR DESCRIPTION
resolves #341, resolves #340, resolves #333

- Reworked tests for dice
  - Moved `createMockData` and `createMockAttackData` into tests as they were only used there
  - Updated  `createMockRoll` to properly mock a roll as needed by tests
  - Rewrote the tests for `attackIsSuccess` to better explain functionality
  - Rewrote `digestAttackResult` tests
    - Updated `createMockRoll` calls
    - #340 : Added tests for these cases
    - Reformulated `createMockRoll` calls to calculate values instead of using hard-coded values.
      - Calculations include calculating attack bonus from thac0 score.
  - Rewrote `sendAttackRoll` tests
    - Removed majority of tests that were just checking the chat messages for content
    - Updated the mocking data to more accurately represent actual data from weapon rolling
- Dice helper
  - Fixed `digestResult`
    - Added description
    - Didn't use proper value for `die`
  - Reworked `attackIsSuccess` to make it more understandable. 
    - Added description
    - To use it will take:
      - `roll, target, bonus` for Ascending AC
      - `roll, thac0, ac` for Descending AC
    - Linted the last `if return` statement.
    - #342: Incorporates the changes in said PR.
  - Rewrote `digestAttackResult`
    - Added description
    - #333 : Updated default AC and AAC values to always allow to hit target unless target is selected (except for natural 1s).
    - #341 : Rewrote logic to support Ascending AC & Descending AC utilizing `attackIsSuccess`
    - Properly flags when an Ascending AC roll fails (previously didn't set `result.isFailure`)
  - Added description for `sendAttackRoll`