### PR TITLE
fix(party): Fix recursive folder adding for 1.8.x

### DIFF
--- a/src/module/party/party-sheet.js
+++ b/src/module/party/party-sheet.js
@@ -119,11 +119,11 @@ export default class OsePartySheet extends FormApplication {
 
   _recursiveAddFolder(folder) {
     folder.contents.forEach((actor) => this._addActorToParty(actor));
-    folder.children.forEach((folder) => this._recursiveAddFolder(folder));
+    folder.children.forEach((folder) => this._recursiveAddFolder(folder.folder));
   }
 
   async _onDropFolder(event, data) {
-    if (data.documentName !== "Actor") {
+    if (data.documentName !== "Folder") {
       return;
     }
 

--- a/src/module/party/party-sheet.js
+++ b/src/module/party/party-sheet.js
@@ -123,7 +123,7 @@ export default class OsePartySheet extends FormApplication {
   }
 
   async _onDropFolder(event, data) {
-    if (data.documentName !== "Folder") {
+    if (data.documentName !== "Actor") {
       return;
     }
 


### PR DESCRIPTION
Fixes an issue that was discovered during testing, that if a folder containing a folder that contains an actor. Dragging the head parent folder into the party sheet doesn't add the actor to the party. This should fix all levels of recursion.