### PR TITLE
fix(macro): Allow macro to be dragged to hotbar for 1.8.x

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -312,6 +312,7 @@
   "OSE.warn.moreThanOneItemWithName": "Your controlled Actor {actorName} has more than one Item with name {itemName}. The first matched Item will be chosen.",
   "OSE.warn.macrosOnlyForOwnedItems": "Only Items owned by Actor may be used to create macros.",
   "OSE.warn.macrosNoTokenOwnedInScene": "No controlled token in scene",
+  "OSE.warn.macrosNotAnItem": "Unable to create macro, not an item.",
 
   "OSE.error.macrosOnlyForOwnedItems": "You can only create macro buttons for owned Items",
   "OSE.error.noItemWithName": "Your controlled Actor {actorName} does not have an item named {itemName}.",

--- a/src/module/helpers-macros.js
+++ b/src/module/helpers-macros.js
@@ -11,10 +11,16 @@
  *
  * @param {object} data - The dropped data
  * @param {number} slot - The hotbar slot to use
- * @returns {Promise}
+ * @returns {Promise} - Promise of assigned macro or a notification
  */
 export async function createOseMacro(data, slot) {
-  if (data.type !== "Item") return;
+  if (data.type === "Macro") {
+    return game.user.assignHotbarMacro(await fromUuid(data.uuid), slot);
+  }
+  if (data.type !== "Item")
+    return ui.notifications.warn(
+      game.i18n.localize("OSE.warn.macrosNotAnItem")
+    );
   if (data.uuid.indexOf("Item.") <= 0)
     return ui.notifications.warn(
       game.i18n.localize("OSE.warn.macrosOnlyForOwnedItems")
@@ -35,8 +41,7 @@ export async function createOseMacro(data, slot) {
       flags: { "ose.itemMacro": true },
     });
   }
-  game.user.assignHotbarMacro(macro, slot);
-  return false;
+  return game.user.assignHotbarMacro(macro, slot);
 }
 
 /* -------------------------------------------- */
@@ -45,8 +50,8 @@ export async function createOseMacro(data, slot) {
  * Create a Macro from an Item drop.
  * Get an existing item macro if one exists, otherwise create a new one.
  *
- * @param {string} itemName
- * @returns {Promise}
+ * @param {string} itemName - Name of item to roll
+ * @returns {Promise} - Promise of item roll or notification
  */
 export function rollItemMacro(itemName) {
   const speaker = ChatMessage.getSpeaker();


### PR DESCRIPTION
Macros were not permitted to be dragged to the hotbar as it was restricted to creating item macros. This fixes that behaviour.

Also adds a notification (with localization) that properly warns that the user tries to create a macro from a non-item if that is the case.