### PR TITLE
fix(container): Correctly return weight when container is empty for 1.8.x

### DIFF
--- a/src/module/item/data-model-container.js
+++ b/src/module/item/data-model-container.js
@@ -29,11 +29,14 @@ export default class OseDataModelContainer extends foundry.abstract.DataModel {
   }
 
   get totalWeight() {
-    return this.contents.reduce(
-      (acc, { system: { weight, quantity } }) =>
-        acc + weight * (quantity?.value || 1),
-      0
-    );
+    if (this.content) {
+      return this.contents.reduce(
+        (acc, { system: { weight, quantity } }) =>
+          acc + weight * (quantity?.value || 1),
+        0
+      );
+    }
+    return 0;
   }
 
   get manualTags() {


### PR DESCRIPTION
If a container didn't have any content, the request for `totalWeight` just didn't return anything, now it returns 0.