### PR TITLE
fix(item): Make spendSpell async for 1.8.x

### DIFF
--- a/src/module/item/entity.js
+++ b/src/module/item/entity.js
@@ -152,9 +152,11 @@ export default class OseItem extends Item {
     });
   }
 
-  spendSpell = async () => {
+  async spendSpell() {
     if (this.type !== "spell")
-      throw new Error("Trying to spend a spell on an item that is not a spell.");
+      throw new Error(
+        "Trying to spend a spell on an item that is not a spell."
+      );
 
     const itemData = this.system;
     await this.update({
@@ -163,7 +165,7 @@ export default class OseItem extends Item {
       },
     });
     await this.show({ skipDialog: true });
-  };
+  }
 
   _getRollTag(data) {
     if (data.roll) {

--- a/src/module/item/entity.js
+++ b/src/module/item/entity.js
@@ -152,16 +152,18 @@ export default class OseItem extends Item {
     });
   }
 
-  spendSpell() {
+  spendSpell = async () => {
+    if (this.type !== "spell")
+      throw new Error("Trying to spend a spell on an item that is not a spell.");
+
     const itemData = this.system;
-    this.update({
-      data: {
+    await this.update({
+      system: {
         cast: itemData.cast - 1,
       },
-    }).then(() => {
-      this.show({ skipDialog: true });
     });
-  }
+    await this.show({ skipDialog: true });
+  };
 
   _getRollTag(data) {
     if (data.roll) {


### PR DESCRIPTION
During testing it was found that `spendSpell` needs to be asynchronous as it involves updating the actors, and rendering chat cards.