### PR TITLE
fix(item): Dragging a container onto itself pops it from inventory sheet

### DIFF
--- a/src/module/actor/actor-sheet.js
+++ b/src/module/actor/actor-sheet.js
@@ -289,6 +289,9 @@ export default class OseActorSheet extends ActorSheet {
 
     const isContainer = this.actor.items.get(item.system.containerId);
 
+    // Issue #357
+    if (item.id === targetId) return;
+
     if (!exists && !targetIsContainer)
       // eslint-disable-next-line no-underscore-dangle
       return this._onDropItemCreate([itemData]);

--- a/src/module/actor/actor-sheet.js
+++ b/src/module/actor/actor-sheet.js
@@ -289,7 +289,7 @@ export default class OseActorSheet extends ActorSheet {
 
     const isContainer = this.actor.items.get(item.system.containerId);
 
-    // Issue #357
+    // Issue: https://github.com/vttred/ose/issues/357
     if (item.id === targetId) return;
 
     if (!exists && !targetIsContainer)

--- a/src/module/actor/actor-sheet.js
+++ b/src/module/actor/actor-sheet.js
@@ -277,21 +277,26 @@ export default class OseActorSheet extends ActorSheet {
   }
 
   async _onDropItem(event, data) {
+    const targetId = event.target.closest(".item")?.dataset?.itemId;
+    const targetItem = this.actor.items.get(targetId);
+    const targetIsContainer = targetItem?.type === "container";
+
+    // This eats the event.target as it is parsed with the TextEditor.
     const item = await Item.implementation.fromDropData(data);
     const itemData = item.toObject();
 
     const exists = !!this.actor.items.get(item.id);
 
-    if (!exists) return this._onDropItemCreate([itemData]);
-
     const isContainer = this.actor.items.get(item.system.containerId);
 
+    if (!exists && !targetIsContainer)
+      // eslint-disable-next-line no-underscore-dangle
+      return this._onDropItemCreate([itemData]);
+
+    // eslint-disable-next-line no-underscore-dangle
     if (isContainer) return this._onContainerItemRemove(item, isContainer);
 
-    const { itemId: targetId } = event.target.closest(".item").dataset;
-    const targetItem = this.actor.items.get(targetId);
-    const targetIsContainer = targetItem?.type === "container";
-
+    // eslint-disable-next-line no-underscore-dangle
     if (targetIsContainer) return this._onContainerItemAdd(item, targetItem);
   }
 
@@ -303,26 +308,35 @@ export default class OseActorSheet extends ActorSheet {
   }
 
   async _onContainerItemAdd(item, target) {
-    const itemData = item.toObject();
-    const container = this.object.items.get(target.id);
-
-    const containerId = container.id;
-    const itemObj = this.object.items.get(item.id);
-    const alreadyExists = container.system.itemIds.find(
+    const alreadyExistsInActor = target.parent.items.find(
       (i) => i.id === item.id
     );
-    if (!alreadyExists) {
-      const newList = [...container.system.itemIds, item.id];
-      await container.update({ system: { itemIds: newList } });
-      await itemObj.update({ system: { containerId: container.id } });
+    let latestItem = item;
+    if (!alreadyExistsInActor) {
+      // eslint-disable-next-line no-underscore-dangle
+      const newItem = await this._onDropItemCreate([item.toObject()]);
+      latestItem = newItem.pop();
+    }
+
+    const alreadyExistsInContainer = target.system.itemIds.find(
+      (i) => i.id === latestItem.id
+    );
+    if (!alreadyExistsInContainer) {
+      const newList = [...target.system.itemIds, latestItem.id];
+      await target.update({ system: { itemIds: newList } });
+      await latestItem.update({ system: { containerId: target.id } });
     }
   }
 
-  async _onDropItemCreate(itemData, container = false) {
+  // eslint-disable-next-line no-underscore-dangle, consistent-return
+  async _onDropItemCreate(droppedItem, targetContainer = false) {
     // override to fix hidden items because their original containers don't exist on this actor
-    itemData = Array.isArray(itemData) ? itemData : [itemData];
-    itemData.forEach((item) => {
+    const droppedItemArray = Array.isArray(droppedItem)
+      ? droppedItem
+      : [droppedItem];
+    droppedItemArray.forEach((item) => {
       if (item.system.containerId && item.system.containerId !== "")
+        // eslint-disable-next-line no-param-reassign
         item.system.containerId = "";
       if (
         item.type === "container" &&
@@ -331,20 +345,21 @@ export default class OseActorSheet extends ActorSheet {
         // itemIds was double stringified to fix strange behavior with stringify blanking our Arrays
         const containedItems = JSON.parse(item.system.itemIds);
         containedItems.forEach((containedItem) => {
+          // eslint-disable-next-line no-param-reassign
           containedItem.system.containerId = "";
         });
-        itemData.push(...containedItems);
+        droppedItem.push(...containedItems);
       }
     });
-    if (!container) {
-      return this.actor.createEmbeddedDocuments("Item", itemData);
+    if (!targetContainer) {
+      return this.actor.createEmbeddedDocuments("Item", droppedItem);
     }
 
-    const { itemIds } = container.system;
-    itemIds.push(itemData.id);
-    const item = this.actor.items.get(itemData[0]._id);
-    await item.update({ system: { containerId: container.id } });
-    await container.update({ system: { itemIds } });
+    const { itemIds } = targetContainer.system;
+    itemIds.push(droppedItem.id);
+    const item = this.actor.items.get(droppedItem[0].id);
+    await item.update({ system: { containerId: targetContainer.id } });
+    await targetContainer.update({ system: { itemIds } });
   }
 
   /* -------------------------------------------- */


### PR DESCRIPTION
Resolves #357 

This is built upon fixes of item drag'n'drop that I've written for #356. I'll keep this in draft until #356 is merged into `1.8.x` as well as the fixes I've yet to create a PR for.

This introduces a simple check that if the item is being dragged onto itself, it does nothing in terms of rearranging the inventory.