### PR TITLE
add `preferedType` to weapon roll options

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -16,6 +16,7 @@
   "OSE.dialog.partysheetplaceholder": "Add Characters to the Party by dragging and dropping them into this window.",
   "OSE.dialog.partyselect": "Select PCs",
   "OSE.dialog.createItem": "Create Item",
+  "OSE.dialog.attackType": "Choose Attack Range",
   "OSE.dialog.itemType": "Item type",
   "OSE.dialog.itemName": "Item name",
   "OSE.dialog.xp.deal": "Deal XP",

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -26,6 +26,7 @@ export type OseConfig = {
   armor: Record<Armor, string>;
   colors: Record<Color, string>;
   languages: string[];
+  attack_types: Record<AttackType, AttackType>,
   auto_tags: {[n: string]: {label: string, icon: string}};
   tags: Record<InventoryItemTag, string>;
   tag_images: Record<InventoryItemTag, string>;
@@ -49,6 +50,7 @@ export type Color =
   | "blue"
   | "orange"
   | "white";
+export type AttackType = "missile" | "melee" | "attack";
 export type InventoryItemTag =
   | "melee"
   | "missile"
@@ -177,6 +179,11 @@ export const OSE: OseConfig = {
     splash: "OSE.items.Splash",
     reload: "OSE.items.Reload",
     charge: "OSE.items.Charge",
+  },
+  attack_types: {
+    missile: "missile",
+    melee: "melee",
+    attack: "attack",
   },
   auto_tags: {
 		get melee() {

--- a/src/module/item/entity.js
+++ b/src/module/item/entity.js
@@ -84,29 +84,33 @@ export class OseItem extends Item {
     };
 
     if (itemData.missile && itemData.melee && !isNPC) {
-      // Dialog
-      new Dialog({
-        title: "Choose Attack Range",
-        content: "",
-        buttons: {
-          melee: {
-            icon: '<i class="fas fa-fist-raised"></i>',
-            label: "Melee",
-            callback: () => {
-              this.actor.targetAttack(rollData, "melee", options);
+      if (options.preferedType === "melee" || options.preferedType === "missile"){
+        type = options.preferedType;
+      } else {
+        // Dialog
+        new Dialog({
+          title: "Choose Attack Range",
+          content: "",
+          buttons: {
+            melee: {
+              icon: '<i class="fas fa-fist-raised"></i>',
+              label: "Melee",
+              callback: () => {
+                this.actor.targetAttack(rollData, "melee", options);
+              },
+            },
+            missile: {
+              icon: '<i class="fas fa-bullseye"></i>',
+              label: "Missile",
+              callback: () => {
+                this.actor.targetAttack(rollData, "missile", options);
+              },
             },
           },
-          missile: {
-            icon: '<i class="fas fa-bullseye"></i>',
-            label: "Missile",
-            callback: () => {
-              this.actor.targetAttack(rollData, "missile", options);
-            },
-          },
-        },
-        default: "melee",
-      }).render(true);
-      return true;
+          default: "melee",
+        }).render(true);
+        return true;
+      }
     } else if (itemData.missile && !isNPC) {
       type = "missile";
     }


### PR DESCRIPTION
this will allow macros to fully automate type of attacks, in addition to `skipDialog`

another API option I would like to add if this is acceptable: attack modifier