### PR TITLE
Apply damage to original attack target

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -202,6 +202,7 @@
   "OSE.Setting.applyDamageOptionHint": "Which token(s) to apply damage to on an attack roll",
   "OSE.Setting.damageSelected": "Selected",
   "OSE.Setting.damageTarget": "Target",
+  "OSE.Setting.damageOriginalTarget": "Original Target",
   "OSE.Setting.InvertedCtrlBehavior": "Invert Roll Ctrl/Meta-key",
   "OSE.Setting.InvertedCtrlBehaviorHint": "Reverses behavior for holding Ctrl/Meta when clicking on a roll.",
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -319,5 +319,7 @@
   "OSE.error.notEnoughGP": "This Actor doesn't have enough GP to pay for its inventory.",
   "OSE.error.itemNoLongerExistsOnActor": "The requested Item {itemId} no longer exists on Actor {actorName}.",
   "OSE.error.noTokenControlled": "You must have one or more controlled Tokens in order to use this option.",
-  "OSE.error.noGP": "You need a GP item to use this feature."
+  "OSE.error.noGP": "You need a GP item to use this feature.",
+  "OSE.error.unexpectedSettings": "unexpected OSE setting {configName}: {configValue}",
+  "OSE.error.cantDealDamageTo": "Can't deal damage to {nameOrId}"
 }

--- a/src/module/chat.ts
+++ b/src/module/chat.ts
@@ -3,11 +3,11 @@ import { OseActor } from "./actor/entity";
 function canApplyDamage(html: JQuery) {
   if (!html.find('.dice-total').length) return false;
   switch (game.settings.get(game.system.id, "applyDamageOption")) {
-    case "originalTarget":
+    case CONFIG.OSE.apply_damage_options.originalTarget:
       return !!html.find(".chat-target").last().data("id");
-    case "targeted":
+    case CONFIG.OSE.apply_damage_options.targeted:
       return !!game.user?.targets?.size;
-    case "selected":
+    case CONFIG.OSE.apply_damage_options.selected:
       return !!canvas.tokens?.controlled.length;
     default: {
       console.log('unknown setting');
@@ -84,17 +84,17 @@ export const addChatMessageButtons = function (msg: ChatMessage, html: JQuery) {
 function applyChatCardDamage(html: JQuery, multiplier: 1 | -1) {
   const amount = html.find(".dice-total").last().text();
   const dmgTgt = game.settings.get(game.system.id, "applyDamageOption");
-  if (dmgTgt === `originalTarget`) {
+  if (dmgTgt === CONFIG.OSE.apply_damage_options.originalTarget) {
     const victimId = html.find(".chat-target").last().data("id");
     (async () => {
       const actor = ((await fromUuid(victimId || '')) as TokenDocument)?.actor;
       await applyDamageToTarget(actor, amount, multiplier, actor?.name || victimId || 'original target');
     })();
   }
-  if (dmgTgt === `targeted`) {
+  if (dmgTgt === CONFIG.OSE.apply_damage_options.targeted) {
     game.user?.targets.forEach((t) => applyDamageToTarget(t.actor, amount, multiplier, t.name));
   }
-  if (dmgTgt === `selected`) {
+  if (dmgTgt === CONFIG.OSE.apply_damage_options.selected) {
     canvas.tokens?.controlled.forEach((t) => applyDamageToTarget(t.actor, amount, multiplier, t.name));
   }
 }

--- a/src/module/chat.ts
+++ b/src/module/chat.ts
@@ -11,7 +11,10 @@ function canApplyDamage(html: JQuery) {
     case CONFIG.OSE.apply_damage_options.selected:
       return !!canvas.tokens?.controlled.length;
     default: {
-      ui.notifications?.error(`unexpected OSE setting applyDamageOption: ${applyDamageOption}`);
+      ui.notifications?.error(game.i18n.format("OSE.error.unexpectedSettings", {
+        configName: 'applyDamageOption',
+        configValue: applyDamageOption,
+      }));
       return false;
     }
   }
@@ -102,7 +105,7 @@ function applyChatCardDamage(html: JQuery, multiplier: 1 | -1) {
 
 async function applyDamageToTarget(actor: Actor | null, amount: string, multiplier: 1 | -1, nameOrId: string) {
   if (!game.user?.isGM || !(actor instanceof OseActor)) {
-    ui.notifications?.error(`Can't deal damage to ${nameOrId}`);
+    ui.notifications?.error(game.i18n.format("OSE.error.cantDealDamageTo", { nameOrId }));
     return;
   }
   await actor.applyDamage(amount, multiplier);

--- a/src/module/chat.ts
+++ b/src/module/chat.ts
@@ -68,18 +68,23 @@ export const addChatMessageButtons = function (msg: ChatMessage, html: JQuery) {
  */
 function applyChatCardDamage(roll: JQuery, multiplier: 1 | -1) {
   const amount = roll.find(".dice-total").last().text();
-  const dmgTgt = game.settings.get(game.system.id, "applyDamageOption");
-  if (dmgTgt === `targeted`) {
-    game.user?.targets.forEach(async (t) => {
-      if (game.user?.isGM && t.actor instanceof OseActor)
-        await t.actor.applyDamage(amount, multiplier);
-    });
-  }
-  if (dmgTgt === `selected`) {
-    canvas.tokens?.controlled.forEach(async (t) => {
-      if (game.user?.isGM && t.actor instanceof OseActor)
-        await t.actor.applyDamage(amount, multiplier);
-    });
+  const victimId = roll.find(".chat-target").last().data("id");
+  if (victimId) {
+    // TODO implement
+  } else {
+    const dmgTgt = game.settings.get(game.system.id, "applyDamageOption");
+    if (dmgTgt === `targeted`) {
+      game.user?.targets.forEach(async (t) => {
+        if (game.user?.isGM && t.actor instanceof OseActor)
+          await t.actor.applyDamage(amount, multiplier);
+      });
+    }
+    if (dmgTgt === `selected`) {
+      canvas.tokens?.controlled.forEach(async (t) => {
+        if (game.user?.isGM && t.actor instanceof OseActor)
+          await t.actor.applyDamage(amount, multiplier);
+      });
+    }
   }
 }
 

--- a/src/module/chat.ts
+++ b/src/module/chat.ts
@@ -2,7 +2,8 @@ import { OseActor } from "./actor/entity";
 
 function canApplyDamage(html: JQuery) {
   if (!html.find('.dice-total').length) return false;
-  switch (game.settings.get(game.system.id, "applyDamageOption")) {
+  const applyDamageOption = game.settings.get(game.system.id, "applyDamageOption");
+  switch (applyDamageOption) {
     case CONFIG.OSE.apply_damage_options.originalTarget:
       return !!html.find(".chat-target").last().data("id");
     case CONFIG.OSE.apply_damage_options.targeted:
@@ -10,7 +11,7 @@ function canApplyDamage(html: JQuery) {
     case CONFIG.OSE.apply_damage_options.selected:
       return !!canvas.tokens?.controlled.length;
     default: {
-      console.log('unknown setting');
+      ui.notifications?.error(`unexpected OSE setting applyDamageOption: ${applyDamageOption}`);
       return false;
     }
   }

--- a/src/module/chat.ts
+++ b/src/module/chat.ts
@@ -1,5 +1,22 @@
 import { OseActor } from "./actor/entity";
 
+function canApplyDamage(html: JQuery) {
+  if (html.find(".dice-total").length)
+    switch (game.settings.get(game.system.id, "applyDamageOption")) {
+      case "originalTarget":
+        return html.find(".chat-target").last().data("id");
+      case "targeted":
+        return !!game.user?.targets?.size;
+      case "selected":
+        return !!canvas.tokens?.controlled.length;
+      default: {
+        console.log('unknown setting');
+        return false;
+      }
+    }
+  return false;
+}
+
 /**
  * This function is used to hook into the Chat Log context menu to add additional options to each message
  * These options make it easy to conveniently apply damage to controlled tokens based on the value of a Roll
@@ -8,8 +25,7 @@ export const addChatMessageContextOptions = function (
   _: JQuery,
   options: ContextMenuEntry[]
 ) {
-  let canApply: ContextMenuEntry["condition"] = (li) =>
-    !!canvas.tokens?.controlled.length && !!li.find(".dice-roll").length;
+  let canApply: ContextMenuEntry["condition"] = (li) => canApplyDamage(li) && !!li.find(".dice-roll").length;
   options.push(
     {
       name: game.i18n.localize("OSE.messages.applyDamage"),
@@ -45,7 +61,7 @@ export const addChatMessageButtons = function (msg: ChatMessage, html: JQuery) {
   }
   // Buttons
   let roll = html.find(".damage-roll");
-  if (roll.length > 0) {
+  if (roll.length > 0 && canApplyDamage(html)) {
     roll.append(
       $(
         `<div class="dice-damage"><button type="button" data-action="apply-damage"><i class="fas fa-tint"></i></button></div>`
@@ -53,7 +69,7 @@ export const addChatMessageButtons = function (msg: ChatMessage, html: JQuery) {
     );
     roll.find('button[data-action="apply-damage"]').on("click", (ev) => {
       ev.preventDefault();
-      applyChatCardDamage(roll, 1);
+      applyChatCardDamage(html, 1);
     });
   }
 };
@@ -62,29 +78,39 @@ export const addChatMessageButtons = function (msg: ChatMessage, html: JQuery) {
  * Apply rolled dice damage to the token or tokens which are currently controlled.
  * This allows for damage to be scaled by a multiplier to account for healing, critical hits, or resistance
  *
- * @param {HTMLElement} roll    The chat entry which contains the roll data
+ * @param {HTMLElement} html    The chat entry which contains the roll data
  * @param {Number} multiplier   A damage multiplier to apply to the rolled damage.
  * @return {Promise}
  */
-function applyChatCardDamage(roll: JQuery, multiplier: 1 | -1) {
-  const amount = roll.find(".dice-total").last().text();
-  const victimId = roll.find(".chat-target").last().data("id");
-  if (victimId) {
-    // TODO implement
-  } else {
-    const dmgTgt = game.settings.get(game.system.id, "applyDamageOption");
-    if (dmgTgt === `targeted`) {
-      game.user?.targets.forEach(async (t) => {
-        if (game.user?.isGM && t.actor instanceof OseActor)
-          await t.actor.applyDamage(amount, multiplier);
-      });
+function applyChatCardDamage(html: JQuery, multiplier: 1 | -1) {
+  const amount = html.find(".dice-total").last().text();
+  const dmgTgt = game.settings.get(game.system.id, "applyDamageOption");
+  if (dmgTgt === `originalTarget`) {
+    const victimId = html.find(".chat-target").last().data("id");
+    if (victimId) {
+      (async () => {
+        const actor = ((await fromUuid(victimId)) as TokenDocument)?.actor;
+        if (actor instanceof OseActor) {
+          await actor.applyDamage(amount, multiplier);
+        } else {
+          ui.notifications?.error(`Can't deal damage to ${victimId}`);
+        }
+      })();
+    } else {
+      ui.notifications?.error(`Can't find original target to deal damage`);
     }
-    if (dmgTgt === `selected`) {
-      canvas.tokens?.controlled.forEach(async (t) => {
-        if (game.user?.isGM && t.actor instanceof OseActor)
-          await t.actor.applyDamage(amount, multiplier);
-      });
-    }
+  }
+  if (dmgTgt === `targeted`) {
+    game.user?.targets.forEach(async (t) => {
+      if (game.user?.isGM && t.actor instanceof OseActor)
+        await t.actor.applyDamage(amount, multiplier);
+    });
+  }
+  if (dmgTgt === `selected`) {
+    canvas.tokens?.controlled.forEach(async (t) => {
+      if (game.user?.isGM && t.actor instanceof OseActor)
+        await t.actor.applyDamage(amount, multiplier);
+    });
   }
 }
 

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -136,8 +136,8 @@ export const OSE: OseConfig = {
   },
   apply_damage_options: {
     selected : "selected",
-    targeted : "selected",
-    originalTarget : "selected",
+    targeted : "targeted",
+    originalTarget : "originalTarget",
   },
   colors: {
     green: "OSE.colors.green",

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -24,6 +24,7 @@ export type OseConfig = {
   saves_short: Record<Save, string>;
   saves_long: Record<Save, string>;
   armor: Record<Armor, string>;
+  apply_damage_options: Record<ApplyDamageOption, ApplyDamageOption>;
   colors: Record<Color, string>;
   languages: string[];
   auto_tags: {[n: string]: {label: string, icon: string}};
@@ -41,6 +42,7 @@ export type ExplorationSkill = "ld" | "od" | "sd" | "fs";
 export type RollType = "result" | "above" | "below";
 export type Save = "death" | "wand" | "paralysis" | "breath" | "spell";
 export type Armor = "unarmored" | "light" | "heavy" | "shield";
+export type ApplyDamageOption = "selected" | "targeted" | "originalTarget";
 export type Color =
   | "green"
   | "red"
@@ -59,7 +61,6 @@ export type InventoryItemTag =
   | "splash"
   | "reload"
   | "charge";
-
 export const OSE: OseConfig = {
   systemPath(): string {
     return `${this.systemRoot}/dist`;
@@ -132,6 +133,11 @@ export const OSE: OseConfig = {
     light: "OSE.armor.light",
     heavy: "OSE.armor.heavy",
     shield: "OSE.armor.shield",
+  },
+  apply_damage_options: {
+    selected : "selected",
+    targeted : "selected",
+    originalTarget : "selected",
   },
   colors: {
     green: "OSE.colors.green",

--- a/src/module/dice.js
+++ b/src/module/dice.js
@@ -156,7 +156,7 @@ export class OseDice {
 
     const targetAc = data.roll.target ? targetActorData.ac.value : 9;
     const targetAac = data.roll.target ? targetActorData.aac.value : 10;
-    result.victim = data.roll.target ? data.roll.target.name : null;
+    result.victim = data.roll.target || null;
 
     if (game.settings.get(game.system.id, "ascendingAC")) {
       if (
@@ -203,11 +203,13 @@ export class OseDice {
     speaker = null,
     form = null,
   } = {}) {
-    if (!data.roll.dmg.filter(v => v !== '').length) {
+    if (!data.roll.dmg.filter((v) => v !== "").length) {
       /**
        * @todo should this error be localized?
        */
-      ui.notifications.error('Attack has no damage dice terms; be sure to set the attack\'s damage');
+      ui.notifications.error(
+        "Attack has no damage dice terms; be sure to set the attack's damage"
+      );
       return;
     }
     const template = `${OSE.systemPath()}/templates/chat/roll-attack.html`;

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -1,3 +1,5 @@
+import { ApplyDamageOption } from "./config";
+
 export const registerSettings = function () {
   game.settings.register(game.system.id, "initiative", {
     name: game.i18n.localize("OSE.Setting.Initiative"),
@@ -108,7 +110,7 @@ declare global {
       "ose.encumbranceOption": "disabled" | "basic" | "detailed" | "complete";
       "ose.significantTreasure": number;
       "ose.languages": string;
-      "ose.applyDamageOption": "selected" | "targeted" | "originalTarget";
+      "ose.applyDamageOption": ApplyDamageOption;
     }
   }
 }

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -84,6 +84,7 @@ export const registerSettings = function () {
     choices: {
       selected: "OSE.Setting.damageSelected",
       targeted: "OSE.Setting.damageTarget",
+      originalTarget: "OSE.Setting.damageOriginalTarget",
     },
   });
   game.settings.register(game.system.id, "invertedCtrlBehavior", {
@@ -107,7 +108,7 @@ declare global {
       "ose.encumbranceOption": "disabled" | "basic" | "detailed" | "complete";
       "ose.significantTreasure": number;
       "ose.languages": string;
-      "ose.applyDamageOption": "selected" | "targeted";
+      "ose.applyDamageOption": "selected" | "targeted" | "originalTarget";
     }
   }
 }

--- a/src/templates/chat/roll-attack.html
+++ b/src/templates/chat/roll-attack.html
@@ -12,8 +12,8 @@
             {{/if}}
         </div>
         {{#if result.victim}}
-        <div class="chat-target">
-            vs {{result.victim}}
+        <div class="chat-target" data-id="{{result.victim.id}}">
+            vs {{result.victim.name}}
         </div>
         {{/if}}
         <div class="blindable" data-blind="{{data.roll.blindroll}}">

--- a/src/templates/chat/roll-attack.html
+++ b/src/templates/chat/roll-attack.html
@@ -12,7 +12,7 @@
             {{/if}}
         </div>
         {{#if result.victim}}
-        <div class="chat-target" data-id="{{result.victim.id}}">
+        <div class="chat-target" data-id="{{result.victim.document.uuid}}">
             vs {{result.victim.name}}
         </div>
         {{/if}}


### PR DESCRIPTION

Add the possibility to inflict damage from an attack to the original target of the attack. The original target is determined at the time of the attack, so even if the atytacking player changed target the damage will go to the right actor. 

Protected by `applyDamageOption` (preexisting) feature flag

fixes #287 

![image](https://user-images.githubusercontent.com/6019373/226107102-a512325f-d573-4381-95d9-6a7cff1e1106.png)
