### PR TITLE
[Suggestion] a different approach for CONFIG.OSE type definitions

### DIFF
--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -14,13 +14,16 @@ export type Color = keyof OseConfig["colors"];
 export type InventoryItemTag = keyof OseConfig["tags"];
 export type EncumbranceOption = keyof OseConfig["encumbranceOptions"];
 
-export const OSE = {
+export const OSE = {  
+  /** Path for system dist */
   systemPath(): string {
     return `${this.systemRoot}/dist`;
-  },
+  },  
+  /** Root path for OSE system */
   get systemRoot(): string {
     return `/systems/${game.system.id}`
   },
+  /** Path for system assets */
   get assetsPath(): string {
     return `${this.systemRoot}/assets`
   },

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -3,64 +3,17 @@ import OseDataModelCharacterEncumbranceComplete from "./actor/data-model-classes
 import OseDataModelCharacterEncumbranceDetailed from "./actor/data-model-classes/data-model-character-encumbrance-detailed";
 import OseDataModelCharacterEncumbranceDisabled from "./actor/data-model-classes/data-model-character-encumbrance-disabled";
 
-export type OseConfig = {
-  /** Path for system dist */
-  systemPath: () => string;
-  /** Root path for OSE system */
-  systemRoot: string;
-  /** Path for system assets */
-  assetsPath: string;
-  /** @todo How do I set this type? */
-  encumbrance: unknown;
-  /** @todo How do I set this type? */
-  encumbranceOptions: {
-    [name: string]: unknown;
-  }
-  scores: Record<Attribute, string>;
-  scores_short: Record<Attribute, string>;
-  exploration_skills: Record<ExplorationSkill, string>;
-  exploration_skills_short: Record<ExplorationSkill, string>;
-  roll_type: Record<RollType, string>;
-  saves_short: Record<Save, string>;
-  saves_long: Record<Save, string>;
-  armor: Record<Armor, string>;
-  colors: Record<Color, string>;
-  languages: string[];
-  auto_tags: {[n: string]: {label: string, icon: string}};
-  tags: Record<InventoryItemTag, string>;
-  tag_images: Record<InventoryItemTag, string>;
-  monster_saves: Record<
-    number,
-    { d: number; w: number; p: number; b: number; s: number }
-  >;
-  monster_thac0: Record<number, number>;
-};
+export type OseConfig = typeof OSE;
 
-export type Attribute = "str" | "int" | "dex" | "wis" | "con" | "cha";
-export type ExplorationSkill = "ld" | "od" | "sd" | "fs";
-export type RollType = "result" | "above" | "below";
-export type Save = "death" | "wand" | "paralysis" | "breath" | "spell";
-export type Armor = "unarmored" | "light" | "heavy" | "shield";
-export type Color =
-  | "green"
-  | "red"
-  | "yellow"
-  | "purple"
-  | "blue"
-  | "orange"
-  | "white";
-export type InventoryItemTag =
-  | "melee"
-  | "missile"
-  | "slow"
-  | "twohanded"
-  | "blunt"
-  | "brace"
-  | "splash"
-  | "reload"
-  | "charge";
+export type Attribute = keyof OseConfig["scores"];
+export type ExplorationSkill = keyof OseConfig["exploration_skills"];
+export type RollType = keyof OseConfig["roll_type"];
+export type Save = keyof OseConfig["saves_long"];
+export type Armor = keyof OseConfig["armor"];
+export type Color = keyof OseConfig["colors"];
+export type InventoryItemTag = keyof OseConfig["tags"];
 
-export const OSE: OseConfig = {
+export const OSE = {
   systemPath(): string {
     return `${this.systemRoot}/dist`;
   },
@@ -319,4 +272,4 @@ export const OSE: OseConfig = {
     20: 6,
     22: 5,
   },
-};
+} as const;

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -12,6 +12,7 @@ export type Save = keyof OseConfig["saves_long"];
 export type Armor = keyof OseConfig["armor"];
 export type Color = keyof OseConfig["colors"];
 export type InventoryItemTag = keyof OseConfig["tags"];
+export type EncumbranceOption = keyof OseConfig["encumbranceOptions"];
 
 export const OSE = {
   systemPath(): string {

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -1,3 +1,5 @@
+import { EncumbranceOption } from "./config";
+
 export const registerSettings = function () {
   game.settings.register(game.system.id, "initiative", {
     name: game.i18n.localize("OSE.Setting.Initiative"),
@@ -52,9 +54,9 @@ export const registerSettings = function () {
     type: String,
     config: true,
     choices: Object.values(CONFIG.OSE.encumbranceOptions)
-      .reduce((obj: {[n:string]: string}, enc) => {
+      .reduce((obj, enc) => {
         return {...obj, [enc.type]: enc.localizedLabel}
-      }, {}),
+      }, {}) as SettingConfig<EncumbranceOption>["choices"],
   });
 
   game.settings.register(game.system.id, "significantTreasure", {


### PR DESCRIPTION
This is how I prefer to define types where there is a single, constant, value: derive the type from the value. It's all based on the `as const` trick.
this removes duplicated structure, so it's easier to change the code while still allows consumers of the configuration object to be type safe.

This nullifies the `@todo How do I set this type?` comments :)