### PR TITLE
fix: Clip long item names off with ellipses.

### DIFF
--- a/src/scss/actor-base.scss
+++ b/src/scss/actor-base.scss
@@ -298,6 +298,8 @@
             line-height: 30px;
             flex-basis: 90px;
             cursor: pointer;
+            text-overflow: ellipsis;
+            white-space: nowrap;
           }
         }
         .item-entry {


### PR DESCRIPTION
## Intent

This changeset clips really long item name text in actor inventories. You can hover over the item's name to see the full name.

![image](https://user-images.githubusercontent.com/1731267/229008855-d97c7113-07bb-4c26-bbb7-1cbc8bb187f4.png)
