### PR TITLE
fix: isNew() tests now check against saves

### DIFF
--- a/src/module/actor/__tests__/data-model-character.test.ts
+++ b/src/module/actor/__tests__/data-model-character.test.ts
@@ -309,6 +309,44 @@ export default ({ describe, it, expect, after, before }: QuenchMethods) => {
       );
       expect(testActor?.system.isNew).to.be.false;
     });
+
+    it("New when all saves are at 0", async () => {
+      const testActor = await createMockActorKey(
+        "monster",
+        {
+          system: {
+            saves: {
+              breath: { value: 0 },
+              death: { value: 0 },
+              paralysis: { value: 0 },
+              spell: { value: 0 },
+              wand: { value: 0 },
+            },
+          },
+        },
+        key
+      );
+      expect(testActor?.system.isNew).to.be.true;
+    });
+
+    it("Not new when any save is above 0", async () => {
+      const testActor = await createMockActorKey(
+        "monster",
+        {
+          system: {
+            saves: {
+              breath: { value: 10 },
+              death: { value: 0 },
+              paralysis: { value: 0 },
+              spell: { value: 0 },
+              wand: { value: 0 },
+            },
+          },
+        },
+        key
+      );
+      expect(testActor?.system.isNew).to.be.false;
+    });
   });
 
   describe("containers()", () => {

--- a/src/module/actor/__tests__/data-model-monster.test.ts
+++ b/src/module/actor/__tests__/data-model-monster.test.ts
@@ -158,18 +158,17 @@ export default ({
   });
 
   describe("isNew()", () => {
-    it("New when all ability scores are at 0", async () => {
+    it("New when all saves are at 0", async () => {
       const testActor = await createMockActorKey(
         "monster",
         {
           system: {
-            scores: {
-              str: { value: 0 },
-              int: { value: 0 },
-              wis: { value: 0 },
-              dex: { value: 0 },
-              con: { value: 0 },
-              cha: { value: 0 },
+            saves: {
+              breath: { value: 0 },
+              death: { value: 0 },
+              paralysis: { value: 0 },
+              spell: { value: 0 },
+              wand: { value: 0 },
             },
           },
         },
@@ -178,18 +177,17 @@ export default ({
       expect(testActor?.system.isNew).to.be.true;
     });
 
-    it("Not new when any ability score is above 0", async () => {
+    it("Not new when any save is above 0", async () => {
       const testActor = await createMockActorKey(
         "monster",
         {
           system: {
-            scores: {
-              str: { value: 10 },
-              int: { value: 0 },
-              wis: { value: 0 },
-              dex: { value: 0 },
-              con: { value: 0 },
-              cha: { value: 0 },
+            saves: {
+              breath: { value: 10 },
+              death: { value: 0 },
+              paralysis: { value: 0 },
+              spell: { value: 0 },
+              wand: { value: 0 },
             },
           },
         },

--- a/src/module/item/entity.js
+++ b/src/module/item/entity.js
@@ -350,6 +350,7 @@ export default class OseItem extends Item {
       actor: this.actor,
       tokenId: token ? `${token.parent.id}.${token.id}` : null,
       item: this._source,
+      itemId: this._source.id,
       data: await this.getChatData(),
       labels: this.labels,
       isHealing: this.isHealing,

--- a/src/module/item/entity.js
+++ b/src/module/item/entity.js
@@ -350,7 +350,6 @@ export default class OseItem extends Item {
       actor: this.actor,
       tokenId: token ? `${token.parent.id}.${token.id}` : null,
       item: this._source,
-      itemId: this._source.id,
       data: await this.getChatData(),
       labels: this.labels,
       isHealing: this.isHealing,


### PR DESCRIPTION
Previously the tests for isNew() assumed that isNew() was written to check the actor's ability scores, and return true if they were all 0. But isNew() was actually written to check the actor's saves, because this is the best indicator for a "new" Character *and* Monster

```js
  get isNew() {
    return !Object.values(this.saves).reduce(
      (prev, curr) => prev + (parseInt(curr?.value, 10) || 0),
      0
    );
  }
```

I've replaced the tests for Data Model : Monster to check saves, not scores. Data Model : Character now has both, because the saves are autogenerated from the scores, and I think it's useful to check that that's still happening properly.