### PR TITLE
fix: containers with phantom items can now delete

### DIFF
--- a/src/module/actor/actor-sheet.js
+++ b/src/module/actor/actor-sheet.js
@@ -112,7 +112,9 @@ export default class OseActorSheet extends ActorSheet {
     if (item.type === "container" && item.system.itemIds) {
       const containedItems = item.system.itemIds;
       const updateData = containedItems.reduce((acc, val) => {
-        acc.push({ _id: val, "system.containerId": "" });
+        // Only create update data for items that still exist on the actor
+        if(this.actor.items.get(val))
+          acc.push({ _id: val, "system.containerId": "" });
         return acc;
       }, []);
 


### PR DESCRIPTION
This is my "elegant" one line fix for #310 

The bug is caused by itemIds that never got removed from container data when the item itself was deleted

There's an argument for creating a migration that removes phantom itemIds from containers rather than using this method. I think we could make an enhancement request for that and remove this?