### PR TITLE
fix: individual init reroll each round now works

### DIFF
--- a/src/module/combat.js
+++ b/src/module/combat.js
@@ -76,8 +76,8 @@ const OseCombat = {
     const combatants = combat?.combatants;
     for (let i = 0; i < combatants.size; i++) {
       const c = combatants.contents[i];
-      // check if actor initiative has already been set for this round
-      if (c?.initiative) {
+      // check if actor initiative has already been set for round 1
+      if (c?.initiative && combat.round === 0) {
         continue;
       }
       // This comes from foundry.js, had to remove the update turns thing


### PR DESCRIPTION
Please read #200. 

I unfortunately don't remember how I arrived at the fix in #280 that resulted in bug #338. I think it was quite difficult to find somewhere else to interrupt the unwanted behavior.

The fix here is once again crude, but it's tough because "Start Combat" and "Next Round" are semantically different operations, and we're kind of cornered into using the same initiative function for each.

I think it's worth considering a future refactor such that changes to one combat roll option no longer impact the other two combat round roll options.