### PR TITLE
fix: now handling lvl in _createItem correctly

### DIFF
--- a/src/module/actor/actor-sheet.js
+++ b/src/module/actor/actor-sheet.js
@@ -402,7 +402,7 @@ export default class OseActorSheet extends ActorSheet {
   _createItem(event) {
     event.preventDefault();
     const header = event.currentTarget;
-    const { treasure, type } = header.dataset;
+    const { treasure, type, lvl } = header.dataset;
     const createItem = (type, name) => ({
       name: name || `New ${type.capitalize()}`,
       type,
@@ -418,6 +418,8 @@ export default class OseActorSheet extends ActorSheet {
     } else {
       const itemData = createItem(type);
       if (treasure) itemData.system = { treasure: true };
+      // when creating a new spell on the character sheet, we need to set the level
+      if (type === "spell") itemData.system = lvl ? { lvl } : {lvl: 1};
       return this.actor.createEmbeddedDocuments("Item", [itemData], {});
     }
   }


### PR DESCRIPTION
Fixes #401. 

Also fixes a previously unreported issue (one I noticed), where the Add Spell button on every Level created Level 1 no matter what Level was in that category.

The fix was simple because we are already passing the lvl number with the event dataset. It was just never handled on the actor sheet logic.