### PR TITLE
fix: no longer add zeroes to rolls

### DIFF
--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -465,25 +465,14 @@ export default class OseActor extends Actor {
     }
     // for each type of attack, add the Tweaks bonus
     // and str/dex modifier only if it's non-zero
-    if (options.type === "missile") {
-      rollParts.push(
-        ...[data.scores.dex.mod, data.thac0.mod.missile].reduce((a, b) => {
-          // if an element of the array is falsy, don't push it to rollParts array
-          if (!b) return a;
-          // otherwise, push it to the rollParts array
-          return [...a, b];
-        }, [])
-      );
-    } else if (options.type === "melee") {
-      rollParts.push(
-        ...[data.scores.str.mod, data.thac0.mod.melee].reduce((a, b) => {
-          // if an element of the array is falsy, don't push it to rollParts array
-          if (!b) return a;
-          // otherwise, push it to the rollParts array
-          return [...a, b];
-        }, [])
-      );
-    }
+    let attackMods = [];
+
+    if (options.type === "missile")
+      attackMods = [data.scores.dex.mod, data.thac0.mod.missile];
+    else if (options.type === "melee")
+      attackMods = [data.scores.str.mod, data.thac0.mod.melee];
+
+    rollParts.push(...attackMods.reduce((a, b) => (b ? [...a, b] : a), []));
 
     const rollData = {
       actor: this,


### PR DESCRIPTION
Fixes #385.

I'm pretty proud of this one! Rather than place a bandaid, I did some refactoring that I think makes for an overall cleaner rollAttack() function :)

Why did I only minimally touch rollDamage()? I can't figure out where this function is actually used. I think it's used nowhere? It will be useful for enhancements such as #332 so I left it in place for now.