### PR TITLE
chore: system.json changes, other superficial changes

### DIFF
--- a/src/scss/apps.scss
+++ b/src/scss/apps.scss
@@ -266,14 +266,8 @@
 }
 
 #settings .ose.game-license {
-  font-size: 12px;
-  .button {
-    text-align: center;
-    margin: 4px;
-  }
-  .footer {
-    text-align: right;
-  }
+  font-size: var(--font-size-12);
+  padding: 10px;
 }
 
 .ose.chat-block {

--- a/src/templates/chat/license.html
+++ b/src/templates/chat/license.html
@@ -1,23 +1,21 @@
 <div class="ose game-license">
-  <p class="ose game-license">
-    Unofficial Old-School Essentials on Foundry VTT <!-- BEGIN TEXT REQUIRED BY LICENSE -->requires <strong><em>Old-School Essentials</em></strong>.<!-- END TEXT REQUIRED BY LICENSE --> Find the game at <a href="https://necroticgnome.com">Necrotic Gnome's website</a>.
+  <p>
+    Simple, robust rules compatible with decades of B/X and OSR content. <a href="https://necroticgnome.com">See the website for full information about Old-School Essentials.</a>
   </p>
   <p>
-    <!-- BEGIN TEXT REQUIRED BY LICENSE -->
-    This third party product is not affiliated with or approved by Necrotic Gnome.
-
-    Old-School Essentials is a trademark of Necrotic Gnome. The trademark and Old-School Essentials logo are used with permission of Necrotic Gnome, under license. <!-- ADDITIONAL TEXT REQUESTED BY NECROTIC GNOME --> Permission to use Old-School Essentials in the ruleset title granted by Necrotic Gnome. <!-- END ADDITIONAL TEXT -->
-    <!-- END TEXT REQUIRED BY LICENSE -->
+    Old-School Essentials is a trademark of Necrotic Gnome, permitted for use under contract.
   </p>
   <p>
-    Brought to life on Foundry VTT by U~man. Currently maintained by Anthony
-    Ronda, who assigns his contributions to VTT Red. See the
-    <a href="https://github.com/vttred/ose/">GitHub repo</a> for a full list of
-    contributors.
+    Report your issues on our
+    <a href="https://github.com/vttred/ose/issues/new">Github issue tracker</a>
+    or by using the Bug Reporter module in Foundry VTT.
   </p>
-  <div class="footer">
-    Report your issues on
-    <a href="https://github.com/vttred/ose/issues">GitHub</a> or by using the
-    Bug Reporter module in Foundry VTT.
-  </div>
+  <p>
+    Open Source Acknowledgements
+  </p>
+  <p>
+    This game system is open source!
+    Brought to life on Foundry VTT by U~man. Currently maintained by VTT Red. See the
+    <a href="https://github.com/vttred/ose/">full list of contributors and license info.</a>
+  </p>
 </div>

--- a/src/templates/chat/license.html
+++ b/src/templates/chat/license.html
@@ -1,21 +1,23 @@
-<div class="ose game-license">
+<section class="ose game-license">
+    <p>
+      Simple, robust rules compatible with decades of Basic/Expert material. <a href="https://necroticgnome.com">See the website</a> for more about Old-School Essentials.
+    </p>
   <p>
-    Simple, robust rules compatible with decades of B/X and OSR content. <a href="https://necroticgnome.com">See the website for full information about Old-School Essentials.</a>
-  </p>
-  <p>
+    <!--IMPORTANT-->
     Old-School Essentials is a trademark of Necrotic Gnome, permitted for use under contract.
+    <!--/IMPORTANT-->
   </p>
   <p>
     Report your issues on our
     <a href="https://github.com/vttred/ose/issues/new">Github issue tracker</a>
     or by using the Bug Reporter module in Foundry VTT.
   </p>
-  <p>
-    Open Source Acknowledgements
-  </p>
+    <h3>
+      Open Source Acknowledgements
+    </h3>
   <p>
     This game system is open source!
-    Brought to life on Foundry VTT by U~man. Currently maintained by VTT Red. See the
-    <a href="https://github.com/vttred/ose/">full list of contributors and license info.</a>
+    Brought to life on Foundry VTT by U~man. Currently maintained by VTT Red. <a href="https://github.com/vttred/ose/">See the
+    project page</a> for a full list of contributors and license info.
   </p>
-</div>
+</section>

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "name": "ose-dev",
   "id": "ose-dev",
   "title": "Old-School Essentials Development Build",
-  "description": "Simple, robust rules compatible with decades of B/X and OSR content",
+  "description": "Simple, robust rules compatible with decades of Basic/Expert material",
   "version": "AUTOMATICALLY REPLACED BY GITHUB WORKFLOW ACTION",
   "minimumCoreVersion": "10",
   "compatibleCoreVersion": "11",

--- a/system.json
+++ b/system.json
@@ -2,14 +2,14 @@
   "name": "ose-dev",
   "id": "ose-dev",
   "title": "Old-School Essentials Development Build",
-  "description": "Play B/X OSR modules with Old-School Essentials on Foundry VTT",
+  "description": "Simple, robust rules compatible with decades of B/X and OSR content",
   "version": "AUTOMATICALLY REPLACED BY GITHUB WORKFLOW ACTION",
   "minimumCoreVersion": "10",
-  "compatibleCoreVersion": "10",
+  "compatibleCoreVersion": "11",
   "compatibility": {
     "minimum": "10",
     "verified": "10",
-    "maximum": 10
+    "maximum": 11
   },
   "author": "Maintained by VTT Red with 16 contributors",
   "authors": [
@@ -67,7 +67,7 @@
       "path": "dist/lang/ca.json"
     },
     {
-      "lang": "zh-CN",
+      "lang": "cn",
       "name": "简体中文 (中国)",
       "path": "dist/lang/zh-CN.json"
     },


### PR DESCRIPTION
- I'm now mildly confident that V11 will not blow up in our faces. I'd like to set our maximum compatible version to 11 a bit earlier than last time, because I think that's best for devs and it's going to be fine for users. There will be a warning that they can't migrate their worlds back to V10
- The core library for Simplified Chinese has a different than expected language tag. This corrects the system.json lang key to the correct value
- Package description and sidebar text updated to use some borrowed OSE marketing copy. Trademark has been permitted for use under contract but I'm only just now doing some housekeeping because someone brought it up on Discord recently