### PR TITLE
fix: item weapon bonus added to attack roll

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -310,6 +310,8 @@
   "OSE.CombatFlag.SpellDeclared": "Spell Declared",
   "OSE.CombatFlag.RetreatFromMeleeDeclared": "Retreat From Melee Declared",
 
+  "OSE.Tweaks.DontApplyWeaponBonusToDamageRoll": "Don't apply weapon bonus to damage roll",
+
   "OSE.warn.moreThanOneItemWithName": "Your controlled Actor {actorName} has more than one Item with name {itemName}. The first matched Item will be chosen.",
   "OSE.warn.macrosOnlyForOwnedItems": "Only Items owned by Actor may be used to create macros.",
   "OSE.warn.macrosNoTokenOwnedInScene": "No controlled token in scene",

--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -1,6 +1,7 @@
+import OseItem from "../item/entity";
+
 import skipRollDialogCheck from "../helpers-behaviour";
 import OseDice from "../helpers-dice";
-import OseItem from "../item/entity";
 
 /**
  * Used in the rollAttack function to remove zeroes from rollParts arrays
@@ -488,6 +489,8 @@ export default class OseActor extends Actor {
       attackMods = [data.scores.dex.mod, data.thac0.mod.missile];
     else if (options.type === "melee")
       attackMods = [data.scores.str.mod, data.thac0.mod.melee];
+
+    if (attData.item) attackMods.push(attData.item?.system?.bonus);
 
     rollParts.push(...removeFalsyElements(attackMods));
 

--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -471,16 +471,16 @@ export default class OseActor extends Actor {
     const dmgParts = removeFalsyElements([
       // Weapon damage roll value
       attData.item?.system?.damage ?? "1d6",
-      // Weapon damage bonus
-      attData.item?.system?.bonus,
     ]);
-
+    if (!this.system.config?.ignoreBonusDamage && attData.item?.system?.bonus)
+      // Weapon Damage Bonus
+      dmgParts.push(attData.item?.system?.bonus);
+ 
     const rollParts = ["1d20"];
     const ascending = game.settings.get(game.system.id, "ascendingAC");
 
-    if (ascending && data.thac0.bba) {
-      rollParts.push(data.thac0.bba);
-    }
+    if (ascending && data.thac0.bba) rollParts.push(data.thac0.bba);
+
     // for each type of attack, add the Tweaks bonus
     // and str/dex modifier only if it's non-zero
     let attackMods = [];

--- a/src/templates/actors/dialogs/tweaks-dialog.html
+++ b/src/templates/actors/dialogs/tweaks-dialog.html
@@ -14,6 +14,13 @@
     </div>
   </div>
   <div class="form-group">
+    <label for="retainer">{{localize "OSE.Tweaks.DontApplyWeaponBonusToDamageRoll"}}</label>
+    <div class="form-fields">
+      <input type="checkbox" name="system.config.ignoreBonusDamage" id="ignoreBonusDamage" {{checked system.config.ignoreBonusDamage}}
+        data-dtype="Boolean" />
+    </div>
+  </div>
+  <div class="form-group">
     <label>{{localize "OSE.InitiativeBonus"}}</label>
     <div class="form-fields">
       <input type="text" name="system.initiative.mod" id="initiative" value="{{@root.system.initiative.mod}}"


### PR DESCRIPTION
The issue in #410 describes the following as a bug

1. The weapon bonus no longer applies to the attack roll
2. The weapon bonus now applies to the damage roll (implemented before 1.8.3, described as unwanted behavior because the damage box can fulfill this demand)

This pull request fixes problem 1. Problem 2 was the result of an intentional change, and I've already released classicfantasycompendium 1.0.0 in accordance with "Bonus" acting like the RAW weapon bonus

In order to help players use different kinds of bonuses, damage only, AC bonus only, etc, I've added a checkbox to the Tweaks menu that allows an actor to ignore the damage half of the weapon bonus on their owned items