### PR TITLE
fix(v11): sidebar license info starts on new line

### DIFF
--- a/src/scss/apps.scss
+++ b/src/scss/apps.scss
@@ -268,6 +268,7 @@
 #settings .ose.game-license {
   font-size: var(--font-size-12);
   padding: 10px;
+  flex-basis: 100%;
 }
 
 .ose.chat-block {


### PR DESCRIPTION
Quick fix in V11testing1's new sidebar layout that keeps the sidebar license info from being in the same row as the system name and version. Going to wait to push until after testing2