### PR TITLE
fix: replaced deprecated systemDataModels config

### DIFF
--- a/src/ose.js
+++ b/src/ose.js
@@ -74,11 +74,11 @@ Hooks.once("init", async () => {
   CONFIG.Actor.documentClass = OseActor;
   CONFIG.Item.documentClass = OseItem;
 
-  CONFIG.Actor.systemDataModels = {
+  CONFIG.Actor.dataModels = {
     character: OseDataModelCharacter,
     monster: OseDataModelMonster,
   };
-  CONFIG.Item.systemDataModels = {
+  CONFIG.Item.dataModels = {
     weapon: OseDataModelWeapon,
     armor: OseDataModelArmor,
     item: OseDataModelItem,


### PR DESCRIPTION
This fixes #416. Waiting for the (hopefully soon to be released) migration guide to see if there are any other deprecated calls I haven't found to be added to this PR