### PR TITLE
fix: compendium folders drag-and-drop

### DIFF
--- a/src/module/actor/actor-sheet.js
+++ b/src/module/actor/actor-sheet.js
@@ -283,11 +283,20 @@ export default class OseActorSheet extends ActorSheet {
     const folder = await fromUuid(data.uuid);
     if (!folder || folder.type !== "Item") return;
 
-    let itemArray = folder.contents;
+    let itemArray = folder.contents || [];
 
     folder.getSubfolders(true).forEach((subfolder) => {
       itemArray.push(...subfolder.contents);
     });
+
+    // Compendium items
+    if (itemArray.length > 0 && itemArray[0]?.uuid?.includes("Compendium")) {
+      const items = [];
+      itemArray.forEach(async (item) => {
+        items.push(await fromUuid(item.uuid));
+      });
+      itemArray = items;
+    }
 
     this._onDropItemCreate(itemArray);
   }


### PR DESCRIPTION
I overlooked the fact that compendium folders need to be loaded into memory from their uuids before being dropped into the actor sheet