### PR TITLE
fix: move details now save to monsters correctly

### DIFF
--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -26,8 +26,10 @@ export default class OseActor extends Actor {
       source.prototypeToken.texture.img = "icons/svg/mystery-man.svg";
     }
     // Fixing missing movement.value by moving it to details.movement
-    if (source?.system?.movement?.value && !source?.system?.details.movement)
+    if (source?.system?.movement?.value && !source?.system?.details.movement){
       source.system.details.movement = source.system.movement.value;
+      delete source.system.movement.value;
+    }
 
     return source;
   }

--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -25,6 +25,10 @@ export default class OseActor extends Actor {
     if (source?.prototypeToken?.texture?.img === "") {
       source.prototypeToken.texture.img = "icons/svg/mystery-man.svg";
     }
+    // Fixing missing movement.value by moving it to details.movement
+    if (source?.system?.movement?.value && !source?.system?.details.movement)
+      source.system.details.movement = source.system.movement.value;
+
     return source;
   }
 

--- a/src/templates/actors/partials/monster-attributes-tab.html
+++ b/src/templates/actors/partials/monster-attributes-tab.html
@@ -145,7 +145,7 @@
                 <li class="attacks-description">
                     {{#unless isNew}}
                     <label>{{ localize "OSE.movement.details" }}</label>
-                    <input name="system.movement.value" type="text" value="{{system.movement.value}}" data-dtype="String" />
+                    <input name="system.details.movement" type="text" value="{{system.details.movement}}" data-dtype="String" />
                     {{else}}
                     <button data-action="generate-saves">{{localize "OSE.dialog.generateSaves"}}</button>
                     {{/unless}}


### PR DESCRIPTION
We had been facing an error where movement details were not getting written to their textbox for a while, and it appeared as though old data may have been wiped. Actually, they were still available in the src of Monster documents, but because their location conflicted with the CharacterMove data model, they were marked as invalid in Foundry and hidden from use.

This changeset moves the movement details storage location to `system.details.movement`, which is more apt for non-gamelogic string data, and creates a data migration where all actors are checked for the old data and moves it to the new location *only* if the new location is empty