### PR TITLE
feat: Issue #425 - Add default "Like Actor Data" for Characters

### DIFF
--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -94,6 +94,26 @@ export default class OseActor extends Actor {
     return this.system.isNew;
   }
 
+  /**
+   * assign more sane defaults to Actor
+   */
+  async _preCreate(data, options, user) {
+    await super._preCreate(data, options, user);
+    // If this Actor came from a Compendium, do not apply defaults.
+    const sourceId = this.getFlag("core", "sourceId");
+    if (sourceId?.startsWith("Compendium.")) return;
+
+    // Configure prototype token settings
+    const prototypeToken = {};
+    if (this.type === "character")
+      Object.assign(prototypeToken, {
+        // sight: { enabled: true }, // Vision -> Basic Configuration -> Vision Enable
+        actorLink: true, // Identity -> Link Actor Data
+        // disposition: 1, // Identity -> Token Disposition = "Friendly"
+      });
+    this.updateSource({ prototypeToken });
+  }
+
   generateSave(hd) {
     hd = hd.includes("+") ? parseInt(hd) + 1 : parseInt(hd);
 


### PR DESCRIPTION
Add default "Link Actor Data" to new Actor's prototypeToken if it's type is character and is not from a Compendium. Also provided two extra options which would be sane but do not cover the Issue, so commented out.