### PR TITLE
fix(OseCharacterCreator): #424 - don't print on close, don't print Failure() on rolls

### DIFF
--- a/src/module/dialog/character-creation.js
+++ b/src/module/dialog/character-creation.js
@@ -11,6 +11,7 @@ export default class OseCharacterCreator extends FormApplication {
     options.id = "character-creator";
     options.template = `${OSE.systemPath()}/templates/actors/dialogs/character-creation.html`;
     options.width = 235;
+    options.submitOnClose = false;
     return options;
   }
 
@@ -98,9 +99,7 @@ export default class OseCharacterCreator extends FormApplication {
         : game.i18n.localize(`OSE.scores.${score}.long`);
     const rollParts = ["3d6"];
     const data = {
-      roll: {
-        type: "result",
-      },
+      roll: {},
     };
     if (options.skipMessage) {
       return new Roll(rollParts[0]).evaluate({ async: false });
@@ -121,27 +120,6 @@ export default class OseCharacterCreator extends FormApplication {
         count: this.counters[score],
       }),
     });
-  }
-
-  async close(options) {
-    // Gather scores
-    const speaker = ChatMessage.getSpeaker({ actor: this });
-    const templateData = {
-      config: CONFIG.OSE,
-      scores: this.scores,
-      title: game.i18n.localize("OSE.dialog.generator"),
-      stats: this.object.stats,
-      gold: this.gold,
-    };
-    const content = await renderTemplate(
-      `${OSE.systemPath()}/templates/chat/roll-creation.html`,
-      templateData
-    );
-    ChatMessage.create({
-      content,
-      speaker,
-    });
-    return super.close(options);
   }
 
   /** @override */
@@ -193,6 +171,26 @@ export default class OseCharacterCreator extends FormApplication {
       preventClose,
       preventRender,
     });
+
+    // Gather scores
+    const speaker = ChatMessage.getSpeaker({ actor: this.object.actor });
+    const templateData = {
+      config: CONFIG.OSE,
+      scores: this.scores,
+      title: game.i18n.localize("OSE.dialog.generator"),
+      stats: this.object.stats,
+      gold: this.gold,
+    };
+    const content = await renderTemplate(
+      `${OSE.systemPath()}/templates/chat/roll-creation.html`,
+      templateData
+    );
+
+    await ChatMessage.create({
+      content,
+      speaker,
+    });
+
     // Generate gold
     const itemData = {
       name: game.i18n.localize("OSE.items.gp.short"),

--- a/src/module/helpers-dice.js
+++ b/src/module/helpers-dice.js
@@ -157,7 +157,13 @@ const OseDice = {
 
         break;
       }
-      // No default
+
+      default : {
+        result.isSuccess = false;
+        result.isFailure = false;
+
+        break;
+      }
     }
     return result;
   },


### PR DESCRIPTION
fix for issue #424 
* sets FormApplication option, submitOnClose to false.
* migrated Gather scores to _onSubmit override
* Added default to data.roll.type check in helpers-dice.js, setting isSuccess AND isFailure to false.
* set data object in call to OseDice.Roll to not provide type Object.

I'd quite like to re-work some of this more. But this resolves the reported issue.

Would like to tidy a bit and add two features:
1) Count re-rolls for manually rolled stats (and present totals in final form)
2) Provide a system option for different rolling standards, such as point buy and roll 4d6, deduct the lowest.