### PR TITLE
fix: Character move speed should calculate normally

### DIFF
--- a/src/module/actor/data-model-classes/__tests__/data-model-character-encumbrance.test.ts
+++ b/src/module/actor/data-model-classes/__tests__/data-model-character-encumbrance.test.ts
@@ -368,9 +368,9 @@ export default ({ describe, it, expect }: QuenchMethods) => {
         ]);
         expect(enc.value).to.equal(max);
 
-      })
-      describe('As fully encumbered flag', () => {
-        it('Encumbered over full load (1600.1)', () => {
+      });
+      describe("As fully encumbered flag", () => {
+        it("Encumbered over full load (1600.1)", () => {
           let enc = new EncumbranceComplete(
             1600,
             [createMockItem('item', 1600.1, 1, { treasure: true })]
@@ -382,32 +382,22 @@ export default ({ describe, it, expect }: QuenchMethods) => {
           );
           expect(enc.encumbered).to.be.true;
         })
-        describe('Not encumbered', () => {
-          it('from a partial load', () => {
-            const enc = new EncumbranceComplete(
-              1600,
-              [createMockItem('item', 400, 1, { treasure: true })]
-            );
-            expect(enc.encumbered).to.be.false;
-          })
-        })
-      });
-      describe("As fully encumbered flag", () => {
-        it("Encumbered at full load", () => {
-          let enc = new EncumbranceComplete(1600, [
-            createMockItem("item", 1600, 1, { treasure: true }),
-          ]);
-          expect(enc.encumbered).to.be.true;
-          enc = new EncumbranceComplete(1600, [
-            createMockItem("item", 1600, 1, { treasure: false }),
-          ]);
-          expect(enc.encumbered).to.be.true;
-        });
         describe("Not encumbered", () => {
           it("from a partial load", () => {
             const enc = new EncumbranceComplete(1600, [
               createMockItem("item", 400, 1, { treasure: true }),
             ]);
+            expect(enc.encumbered).to.be.false;
+          });
+          it("from a full load", () => {
+            let enc = new EncumbranceComplete(1600, [
+              createMockItem("item", 1600, 1, { treasure: true }),
+            ]);
+            expect(enc.encumbered).to.be.false;
+            enc = new EncumbranceComplete(1600, [
+              createMockItem("item", 1600, 1, { treasure: false }),
+            ]);
+            console.info(enc);
             expect(enc.encumbered).to.be.false;
           });
         });

--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -14,7 +14,7 @@ const removeFalsyElements = (arr) =>
 
 export default class OseActor extends Actor {
   prepareDerivedData() {
-    this.system.prepareDerivedData?.();
+    if (game.version.startsWith("10")) this.system.prepareDerivedData?.();
   }
 
   static migrateData(source) {


### PR DESCRIPTION
## Intent
This fixes a v11-exclusive issue wherein `OseActor.system.prepareDerivedData()` was getting called twice. This was caused by a change in v11 that calls `Actor.system.prepareDerivedData` if it exists on the actor's data model. 

## Relevant tests
![image](https://github.com/vttred/ose/assets/1731267/bc97bddf-5dcc-4ca7-aa74-7f3adbbb2f2c)

Fixes #446 
Fixes #447 