### PR TITLE
fix: hp/encumbrance attribute bars restored

### DIFF
--- a/src/module/actor/data-model-character.js
+++ b/src/module/actor/data-model-character.js
@@ -61,7 +61,7 @@ export default class OseDataModelCharacter extends foundry.abstract.DataModel {
 
   // @todo define schema options; stuff like min/max values and so on.
   static defineSchema() {
-    const { StringField, NumberField, BooleanField, ObjectField } =
+    const { StringField, NumberField, BooleanField, ObjectField, SchemaField } =
       foundry.data.fields;
 
     return {
@@ -70,33 +70,36 @@ export default class OseDataModelCharacter extends foundry.abstract.DataModel {
       details: new ObjectField(),
       ac: new ObjectField(),
       aac: new ObjectField(),
-      encumbrance: new ObjectField(),
+      encumbrance: new SchemaField({
+        value: new NumberField({ integer: false }),
+        max: new NumberField({ integer: false }),
+      }),
       movement: new ObjectField(),
       config: new ObjectField(),
       initiative: new ObjectField(),
-      hp: new ObjectField({
+      hp: new SchemaField({
         hd: new StringField(),
         value: new NumberField({ integer: true }),
         max: new NumberField({ integer: true }),
       }),
       thac0: new ObjectField(),
       languages: new ObjectField(),
-      saves: new ObjectField({
-        breath: new ObjectField({ value: new NumberField({ integer: true }) }),
-        death: new ObjectField({ value: new NumberField({ integer: true }) }),
-        paralysis: new ObjectField({
+      saves: new SchemaField({
+        breath: new SchemaField({ value: new NumberField({ integer: true }) }),
+        death: new SchemaField({ value: new NumberField({ integer: true }) }),
+        paralysis: new SchemaField({
           value: new NumberField({ integer: true }),
         }),
-        spell: new ObjectField({ value: new NumberField({ integer: true }) }),
-        wand: new ObjectField({ value: new NumberField({ integer: true }) }),
+        spell: new SchemaField({ value: new NumberField({ integer: true }) }),
+        wand: new SchemaField({ value: new NumberField({ integer: true }) }),
       }),
-      exploration: new ObjectField({
+      exploration: new SchemaField({
         ft: new NumberField({ integer: true, positive: true }),
         ld: new NumberField({ integer: true, positive: true }),
         od: new NumberField({ integer: true, positive: true }),
         sd: new NumberField({ integer: true, positive: true }),
       }),
-      retainer: new ObjectField({
+      retainer: new SchemaField({
         enabled: new BooleanField(),
         loyalty: new NumberField({ integer: true }),
         wage: new StringField(),

--- a/src/module/actor/data-model-monster.js
+++ b/src/module/actor/data-model-monster.js
@@ -24,7 +24,7 @@ export default class OseDataModelMonster extends foundry.abstract.DataModel {
 
   // @todo define schema options; stuff like min/max values and so on.
   static defineSchema() {
-    const { StringField, NumberField, BooleanField, ObjectField } =
+    const { StringField, NumberField, BooleanField, ObjectField, SchemaField } =
       foundry.data.fields;
 
     return {
@@ -32,27 +32,30 @@ export default class OseDataModelMonster extends foundry.abstract.DataModel {
       details: new ObjectField(),
       ac: new ObjectField(),
       aac: new ObjectField(),
-      encumbrance: new ObjectField(),
+      encumbrance: new SchemaField({
+        value: new NumberField({ integer: false }),
+        max: new NumberField({ integer: false }),
+      }),
       movement: new ObjectField(),
       config: new ObjectField(),
       initiative: new ObjectField(),
-      hp: new ObjectField({
+      hp: new SchemaField({
         hd: new StringField(),
         value: new NumberField({ integer: true }),
         max: new NumberField({ integer: true }),
       }),
       thac0: new ObjectField(),
       languages: new ObjectField(),
-      saves: new ObjectField({
-        breath: new ObjectField({ value: new NumberField({ integer: true }) }),
-        death: new ObjectField({ value: new NumberField({ integer: true }) }),
-        paralysis: new ObjectField({
+      saves: new SchemaField({
+        breath: new SchemaField({ value: new NumberField({ integer: true }) }),
+        death: new SchemaField({ value: new NumberField({ integer: true }) }),
+        paralysis: new SchemaField({
           value: new NumberField({ integer: true }),
         }),
-        spell: new ObjectField({ value: new NumberField({ integer: true }) }),
-        wand: new ObjectField({ value: new NumberField({ integer: true }) }),
+        spell: new SchemaField({ value: new NumberField({ integer: true }) }),
+        wand: new SchemaField({ value: new NumberField({ integer: true }) }),
       }),
-      retainer: new ObjectField({
+      retainer: new SchemaField({
         enabled: new BooleanField(),
         loyalty: new NumberField({ integer: true }),
         wage: new StringField(),


### PR DESCRIPTION
Fixes #453. We've discovered that the wrong Datafield subtype (ObjectField) was being used to define parts of the datamodel (correct subtype: SchemaField). This was apparently not crucial to the overall DataModel definition in terms of how Foundry handled our system's data model until DataModel validation changed in V11. Foundry no longer uses template.json as a general schema for finding the fields being used if there's a datamodel definition, so I believe it could no longer find the fields because we were using ObjectField incorrectly

Anyway here's a screenshot from Foundry while testing this changeset

<img width="664" alt="image" src="https://github.com/vttred/ose/assets/1410433/3845b3d4-2ac1-433d-b019-467c38771c60">
