### PR TITLE
fix: needs to be non-static in order to override

### DIFF
--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -34,22 +34,24 @@ export default class OseActor extends Actor {
     return source;
   }
 
-  static async update(data, options = {}) {
+  async update(data, options = {}) {
+    const newData = data;
+
     // Compute AAC from AC
     if (data?.ac?.value) {
-      data.aac = { value: 19 - data.ac.value };
+      newData.aac = { value: 19 - data.ac.value };
     } else if (data?.aac?.value) {
-      data.ac = { value: 19 - data.aac.value };
+      newData.ac = { value: 19 - data.aac.value };
     }
 
     // Compute Thac0 from BBA
     if (data?.thac0?.value) {
-      data.thac0.bba = 19 - data.thac0.value;
+      newData.thac0.bba = 19 - data.thac0.value;
     } else if (data?.thac0?.bba) {
-      data.thac0.value = 19 - data.thac0.bba;
+      newData.thac0.value = 19 - data.thac0.bba;
     }
 
-    super.update(data, options);
+    super.update(newData, options);
   }
 
   async createEmbeddedDocuments(embeddedName, data = [], context = {}) {

--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -36,19 +36,25 @@ export default class OseActor extends Actor {
 
   async update(data, options = {}) {
     const newData = { ...data };
+    const {
+      "system.ac.value": acValue,
+      "system.aac.value": aacValue,
+      "system.thac0.bba": bbaValue,
+      "system.thac0.value": thac0Value,
+    } = newData;
 
     // Compute AAC from AC
-    if (newData["system.ac.value"]) {
-      newData["system.aac.value"] = 19 - newData["system.ac.value"];
-    } else if (newData["system.aac.value"]) {
-      newData["system.ac.value"] = 19 - newData["system.aac.value"];
+    if (acValue) {
+      newData["system.aac.value"] = 19 - acValue;
+    } else if (aacValue) {
+      newData["system.ac.value"] = 19 - aacValue;
     }
 
     // Compute Thac0 from BBA
-    if (newData["system.thac0.value"]) {
-      newData["system.thac0.bba"] = 19 - newData["system.thac0.value"];
-    } else if (newData["system.thac0.bba"]) {
-      newData["system.thac0.value"] = 19 - newData["system.thac0.bba"];
+    if (thac0Value) {
+      newData["system.thac0.bba"] = 19 - thac0Value;
+    } else if (bbaValue) {
+      newData["system.thac0.value"] = 19 - bbaValue;
     }
 
     super.update(newData, options);

--- a/src/module/actor/entity.js
+++ b/src/module/actor/entity.js
@@ -35,20 +35,20 @@ export default class OseActor extends Actor {
   }
 
   async update(data, options = {}) {
-    const newData = data;
+    const newData = { ...data };
 
     // Compute AAC from AC
-    if (data?.ac?.value) {
-      newData.aac = { value: 19 - data.ac.value };
-    } else if (data?.aac?.value) {
-      newData.ac = { value: 19 - data.aac.value };
+    if (newData["system.ac.value"]) {
+      newData["system.aac.value"] = 19 - newData["system.ac.value"];
+    } else if (newData["system.aac.value"]) {
+      newData["system.ac.value"] = 19 - newData["system.aac.value"];
     }
 
     // Compute Thac0 from BBA
-    if (data?.thac0?.value) {
-      newData.thac0.bba = 19 - data.thac0.value;
-    } else if (data?.thac0?.bba) {
-      newData.thac0.value = 19 - data.thac0.bba;
+    if (newData["system.thac0.value"]) {
+      newData["system.thac0.bba"] = 19 - newData["system.thac0.value"];
+    } else if (newData["system.thac0.bba"]) {
+      newData["system.thac0.value"] = 19 - newData["system.thac0.bba"];
     }
 
     super.update(newData, options);


### PR DESCRIPTION
Fixes #460 

This function was changed to static as part of a linting pass. We should be checking that we are not changing overrides to static, however, because in this case it caused this `update()` override to never run. The change to static has been reversed. In order to avoid the linter error "do not mutate function properties" we create a clone of the data object property.

This function also returned undefined for all of its conditionals, because (new)`data.system` doesn't exist. The data object's children are flattened into string-keys like this:
<img width="226" alt="image" src="https://github.com/vttred/ose/assets/1410433/10e8f89d-5b96-45c8-b738-e4da4abecacb">

I switched to this new way of accessing them.

Finally, the linter is complaining about re-using duplicate string literals. This makes no sense in this context, and indeed it should not be triggering because string literals used as object keys are an exception in the SonarSouce/no-duplicate-string rule https://github.com/SonarSource/eslint-plugin-sonarjs/issues/107
