### PR TITLE
Ci/add package release api and build from cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Checkout repository to add to workspace
         uses: actions/checkout@v2
 
-      - name: Setup Node.js version 16
+      - name: Setup Node.js version 18
         uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: "18"
 
       # # Caching to improve build speed
       - name: Enable caching for Node.js modules
@@ -27,12 +27,12 @@ jobs:
             ${{ runner.OS }}-node-
             ${{ runner.OS }}-
 
-      # Get dev dependencies for the package, including Gulp and Rollup
+      # Get dev dependencies for the package, including Rollup
       - name: Install dev dependencies
         run: npm ci #--cache .npm --prefer-offline --ignore-scripts
 
-      # Create a build using Gulp build script
-      - name: Run Gulp build script
+      # Create a build using Rollup build script
+      - name: Run Rollup build script
         run: npm run build
 
       # Insert "manifest", "download", and "version" for this release into the system.json manifest file
@@ -69,3 +69,23 @@ jobs:
           artifacts: "./system.json, ./system.zip"
           tag: ${{ github.event.release.tag_name }}
           body: ${{ github.event.release.body }}
+      # Post to Package Release API
+      - name: Post to Package Release API
+        run: |
+          curl --request POST \
+          --url https://api.foundryvtt.com/_api/packages/release_version \
+          --header 'Authorization: ${{ secrets.FVTT_PACKAGE_RELEASE_TOKEN }}' \
+          --header 'Content-Type: application/json' \
+          --data '{
+            "id": "ose",
+            "release": {
+              "version": "${{ github.event.release.tag_name }}",
+              "manifest": "https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/system.json",
+              "notes": "https://github.com/https://github.com/${{github.repository}}/releases/tag/${{github.event.release.tag_name}}",
+              "compatibility": {
+                "minimum": "11",
+                "verified": "11",
+                "maximum": "11"
+              }
+            }
+          }'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
       # Get dev dependencies for the package, including Rollup
       - name: Install dev dependencies
-        run: npm ci #--cache .npm --prefer-offline --ignore-scripts
+        run: npm ci --cache .npm --prefer-offline --ignore-scripts
 
       # Create a build using Rollup build script
       - name: Run Rollup build script

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ose",
       "version": "0.0.0",
       "devDependencies": {
-        "@league-of-foundry-developers/foundry-vtt-types": "League-of-Foundry-Developers/foundry-vtt-types#main",
+        "@league-of-foundry-developers/foundry-vtt-types": "github:League-of-Foundry-Developers/foundry-vtt-types",
         "@rollup/plugin-eslint": "^9.0.1",
         "@rollup/plugin-node-resolve": "^13.1.3",
         "@rollup/plugin-typescript": "^8.3.4",
@@ -668,28 +668,29 @@
     },
     "node_modules/@league-of-foundry-developers/foundry-vtt-types": {
       "version": "9.269.0",
-      "resolved": "git+ssh://git@github.com/League-of-Foundry-Developers/foundry-vtt-types.git#e8ff8085874871128b66bf8be664071e0140a34c",
+      "resolved": "git+ssh://git@github.com/League-of-Foundry-Developers/foundry-vtt-types.git#4669bf2f295fff33650793972ca75ddf02995692",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pixi/graphics-smooth": "0.0.30",
-        "@pixi/particle-emitter": "5.0.7",
-        "@types/jquery": "~3.5.9",
-        "@types/showdown": "~2.0.0",
+        "@pixi/graphics-smooth": "^0.0.30",
+        "@pixi/particle-emitter": "^5.0.7",
+        "@types/jquery": "~3.5.22",
+        "@types/showdown": "~2.0.2",
         "@types/simple-peer": "~9.11.1",
-        "handlebars": "4.7.7",
-        "pixi.js": "5.3.11",
-        "prosemirror-collab": "1.3.0",
-        "prosemirror-commands": "1.3.0",
-        "prosemirror-inputrules": "1.2.0",
-        "prosemirror-keymap": "1.2.0",
-        "prosemirror-model": "1.18.1",
-        "prosemirror-schema-list": "1.2.1",
-        "prosemirror-state": "1.4.1",
-        "prosemirror-transform": "1.6.0",
-        "prosemirror-view": "1.27.0",
-        "socket.io-client": "4.5.1",
-        "tinymce": "6.1.2"
+        "@types/youtube": "~0.0.48",
+        "handlebars": "^4.7.7",
+        "pixi.js": "^5.3.11",
+        "prosemirror-collab": "^1.3.0",
+        "prosemirror-commands": "^1.3.0",
+        "prosemirror-inputrules": "^1.2.0",
+        "prosemirror-keymap": "^1.2.0",
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-schema-list": "^1.2.1",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-transform": "^1.7.0",
+        "prosemirror-view": "^1.27.2",
+        "socket.io-client": "^4.5.1",
+        "tinymce": "^6.7.0"
       }
     },
     "node_modules/@mdn/browser-compat-data": {
@@ -3182,9 +3183,9 @@
       "dev": true
     },
     "node_modules/@types/jquery": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.14.tgz",
-      "integrity": "sha512-X1gtMRMbziVQkErhTQmSe2jFwwENA/Zr+PprCkF63vFq+Yt5PZ4AlKqgmeNlwgn7dhsXEK888eIW2520EpC+xg==",
+      "version": "3.5.29",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.29.tgz",
+      "integrity": "sha512-oXQQC9X9MOPRrMhPHHOsXqeQDnWeCDT3PelUIg/Oy8FAbzSZtFHRjc7IpbfFVmpLtJ+UOoywpRsuO5Jxjybyeg==",
       "dev": true,
       "dependencies": {
         "@types/sizzle": "*"
@@ -3275,9 +3276,9 @@
       "dev": true
     },
     "node_modules/@types/showdown": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/showdown/-/showdown-2.0.0.tgz",
-      "integrity": "sha512-70xBJoLv+oXjB5PhtA8vo7erjLDp9/qqI63SRHm4REKrwuPOLs8HhXwlZJBJaB4kC18cCZ1UUZ6Fb/PLFW4TCA==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/showdown/-/showdown-2.0.6.tgz",
+      "integrity": "sha512-pTvD/0CIeqe4x23+YJWlX2gArHa8G0J0Oh6GKaVXV7TAeickpkkZiNOgFcFcmLQ5lB/K0qBJL1FtRYltBfbGCQ==",
       "dev": true
     },
     "node_modules/@types/simple-peer": {
@@ -3290,9 +3291,9 @@
       }
     },
     "node_modules/@types/sizzle": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
-      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.8.tgz",
+      "integrity": "sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg==",
       "dev": true
     },
     "node_modules/@types/unist": {
@@ -3309,6 +3310,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/youtube": {
+      "version": "0.0.50",
+      "resolved": "https://registry.npmjs.org/@types/youtube/-/youtube-0.0.50.tgz",
+      "integrity": "sha512-d4GpH4uPYp9W07kc487tiq6V/EUHl18vZWFMbQoe4Sk9LXEWzFi/BMf9x7TI4m7/j7gU3KeX8H6M8aPBgykeLw==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.44.0",
@@ -8734,18 +8741,18 @@
       }
     },
     "node_modules/prosemirror-transform": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.6.0.tgz",
-      "integrity": "sha512-MAp7AjsjEGEqQY0sSMufNIUuEyB1ZR9Fqlm8dTwwWwpEJRv/plsKjWXBbx52q3Ml8MtaMcd7ic14zAHVB3WaMw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.8.0.tgz",
+      "integrity": "sha512-BaSBsIMv52F1BVVMvOmp1yzD3u65uC3HTzCBQV1WDPqJRQ2LuHKcyfn0jwqodo8sR9vVzMzZyI+Dal5W9E6a9A==",
       "dev": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0"
       }
     },
     "node_modules/prosemirror-view": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.27.0.tgz",
-      "integrity": "sha512-yNCQW5eiPkrMgjOT5Xa/ItIvcM7JBG7ikZKaHo26hdBW5OLNnIWGZ0BV6/OiBk742teLybLVNPCpYUcW405Ckg==",
+      "version": "1.32.6",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.32.6.tgz",
+      "integrity": "sha512-26r5LvyDlPgUNVf7ZdNdGrMJnylwjJtUJTfDuYOANIVx9lqWD1WCBlGg283weYQGKUC64DXR25LeAmliB9CrFQ==",
       "dev": true,
       "dependencies": {
         "prosemirror-model": "^1.16.0",
@@ -9862,9 +9869,9 @@
       "dev": true
     },
     "node_modules/tinymce": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.1.2.tgz",
-      "integrity": "sha512-tl4KbEKdPzyPTatJkblN2AqzRj9jaRGyATnwaSnsLFGKb4AI6B+4e0Gc8dUDXuqAjgSnHokhzamrQJLbSn4CmQ==",
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.8.2.tgz",
+      "integrity": "sha512-Lho79o2Y1Yn+XdlTEkHTEkEmzwYWTXz7IUsvPwxJF3VTtgHUIAAuBab29kik+f2KED3rZvQavr9D7sHVMJ9x4A==",
       "dev": true
     },
     "node_modules/to-fast-properties": {
@@ -10854,28 +10861,29 @@
       }
     },
     "@league-of-foundry-developers/foundry-vtt-types": {
-      "version": "git+ssh://git@github.com/League-of-Foundry-Developers/foundry-vtt-types.git#e8ff8085874871128b66bf8be664071e0140a34c",
+      "version": "git+ssh://git@github.com/League-of-Foundry-Developers/foundry-vtt-types.git#4669bf2f295fff33650793972ca75ddf02995692",
       "dev": true,
-      "from": "@league-of-foundry-developers/foundry-vtt-types@League-of-Foundry-Developers/foundry-vtt-types#main",
+      "from": "@league-of-foundry-developers/foundry-vtt-types@github:League-of-Foundry-Developers/foundry-vtt-types",
       "requires": {
-        "@pixi/graphics-smooth": "0.0.30",
-        "@pixi/particle-emitter": "5.0.7",
-        "@types/jquery": "~3.5.9",
-        "@types/showdown": "~2.0.0",
+        "@pixi/graphics-smooth": "^0.0.30",
+        "@pixi/particle-emitter": "^5.0.7",
+        "@types/jquery": "~3.5.22",
+        "@types/showdown": "~2.0.2",
         "@types/simple-peer": "~9.11.1",
-        "handlebars": "4.7.7",
-        "pixi.js": "5.3.11",
-        "prosemirror-collab": "1.3.0",
-        "prosemirror-commands": "1.3.0",
-        "prosemirror-inputrules": "1.2.0",
-        "prosemirror-keymap": "1.2.0",
-        "prosemirror-model": "1.18.1",
-        "prosemirror-schema-list": "1.2.1",
-        "prosemirror-state": "1.4.1",
-        "prosemirror-transform": "1.6.0",
-        "prosemirror-view": "1.27.0",
-        "socket.io-client": "4.5.1",
-        "tinymce": "6.1.2"
+        "@types/youtube": "~0.0.48",
+        "handlebars": "^4.7.7",
+        "pixi.js": "^5.3.11",
+        "prosemirror-collab": "^1.3.0",
+        "prosemirror-commands": "^1.3.0",
+        "prosemirror-inputrules": "^1.2.0",
+        "prosemirror-keymap": "^1.2.0",
+        "prosemirror-model": "^1.18.1",
+        "prosemirror-schema-list": "^1.2.1",
+        "prosemirror-state": "^1.4.1",
+        "prosemirror-transform": "^1.7.0",
+        "prosemirror-view": "^1.27.2",
+        "socket.io-client": "^4.5.1",
+        "tinymce": "^6.7.0"
       }
     },
     "@mdn/browser-compat-data": {
@@ -13193,9 +13201,9 @@
       "dev": true
     },
     "@types/jquery": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.14.tgz",
-      "integrity": "sha512-X1gtMRMbziVQkErhTQmSe2jFwwENA/Zr+PprCkF63vFq+Yt5PZ4AlKqgmeNlwgn7dhsXEK888eIW2520EpC+xg==",
+      "version": "3.5.29",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.29.tgz",
+      "integrity": "sha512-oXQQC9X9MOPRrMhPHHOsXqeQDnWeCDT3PelUIg/Oy8FAbzSZtFHRjc7IpbfFVmpLtJ+UOoywpRsuO5Jxjybyeg==",
       "dev": true,
       "requires": {
         "@types/sizzle": "*"
@@ -13286,9 +13294,9 @@
       "dev": true
     },
     "@types/showdown": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/showdown/-/showdown-2.0.0.tgz",
-      "integrity": "sha512-70xBJoLv+oXjB5PhtA8vo7erjLDp9/qqI63SRHm4REKrwuPOLs8HhXwlZJBJaB4kC18cCZ1UUZ6Fb/PLFW4TCA==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/showdown/-/showdown-2.0.6.tgz",
+      "integrity": "sha512-pTvD/0CIeqe4x23+YJWlX2gArHa8G0J0Oh6GKaVXV7TAeickpkkZiNOgFcFcmLQ5lB/K0qBJL1FtRYltBfbGCQ==",
       "dev": true
     },
     "@types/simple-peer": {
@@ -13301,9 +13309,9 @@
       }
     },
     "@types/sizzle": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
-      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.8.tgz",
+      "integrity": "sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg==",
       "dev": true
     },
     "@types/unist": {
@@ -13320,6 +13328,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/youtube": {
+      "version": "0.0.50",
+      "resolved": "https://registry.npmjs.org/@types/youtube/-/youtube-0.0.50.tgz",
+      "integrity": "sha512-d4GpH4uPYp9W07kc487tiq6V/EUHl18vZWFMbQoe4Sk9LXEWzFi/BMf9x7TI4m7/j7gU3KeX8H6M8aPBgykeLw==",
+      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.44.0",
@@ -17354,18 +17368,18 @@
       }
     },
     "prosemirror-transform": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.6.0.tgz",
-      "integrity": "sha512-MAp7AjsjEGEqQY0sSMufNIUuEyB1ZR9Fqlm8dTwwWwpEJRv/plsKjWXBbx52q3Ml8MtaMcd7ic14zAHVB3WaMw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.8.0.tgz",
+      "integrity": "sha512-BaSBsIMv52F1BVVMvOmp1yzD3u65uC3HTzCBQV1WDPqJRQ2LuHKcyfn0jwqodo8sR9vVzMzZyI+Dal5W9E6a9A==",
       "dev": true,
       "requires": {
         "prosemirror-model": "^1.0.0"
       }
     },
     "prosemirror-view": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.27.0.tgz",
-      "integrity": "sha512-yNCQW5eiPkrMgjOT5Xa/ItIvcM7JBG7ikZKaHo26hdBW5OLNnIWGZ0BV6/OiBk742teLybLVNPCpYUcW405Ckg==",
+      "version": "1.32.6",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.32.6.tgz",
+      "integrity": "sha512-26r5LvyDlPgUNVf7ZdNdGrMJnylwjJtUJTfDuYOANIVx9lqWD1WCBlGg283weYQGKUC64DXR25LeAmliB9CrFQ==",
       "dev": true,
       "requires": {
         "prosemirror-model": "^1.16.0",
@@ -18206,9 +18220,9 @@
       "dev": true
     },
     "tinymce": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.1.2.tgz",
-      "integrity": "sha512-tl4KbEKdPzyPTatJkblN2AqzRj9jaRGyATnwaSnsLFGKb4AI6B+4e0Gc8dUDXuqAjgSnHokhzamrQJLbSn4CmQ==",
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.8.2.tgz",
+      "integrity": "sha512-Lho79o2Y1Yn+XdlTEkHTEkEmzwYWTXz7IUsvPwxJF3VTtgHUIAAuBab29kik+f2KED3rZvQavr9D7sHVMJ9x4A==",
       "dev": true
     },
     "to-fast-properties": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "",
   "license": "",
   "devDependencies": {
-    "@league-of-foundry-developers/foundry-vtt-types": "League-of-Foundry-Developers/foundry-vtt-types#main",
+    "@league-of-foundry-developers/foundry-vtt-types": "github:League-of-Foundry-Developers/foundry-vtt-types",
     "@rollup/plugin-eslint": "^9.0.1",
     "@rollup/plugin-node-resolve": "^13.1.3",
     "@rollup/plugin-typescript": "^8.3.4",


### PR DESCRIPTION
Adds the ability to use this API in CI

https://foundryvtt.com/article/package-release-api/

and re-enables building from cache in CI after this fix

https://github.com/League-of-Foundry-Developers/foundry-vtt-types/pull/2398

(League's Foundry Types has a husky dependency, and husky wants to run scripts upon install–we don't want it to–and it used to error out our build script because it can't find the working directory from its cached directory)
