### PR TITLE
Use webaddress it forwards to

### DIFF
--- a/src/ose.js
+++ b/src/ose.js
@@ -167,7 +167,7 @@ Hooks.on("renderSidebarTab", async (object, html) => {
       `<button type="button" data-action="userguide"><img src='${OSE.assetsPath}/dragon.png' width='16' height='16' style='${styling}'/>Old School Guide</button>`
     ).insertAfter(docs);
     html.find('button[data-action="userguide"]').click(() => {
-      new FrameViewer("https://vttred.github.io/ose", {
+      new FrameViewer("https://ose.vtt.red/", {
         resizable: true,
       }).render(true);
     });


### PR DESCRIPTION
I still can't reproduce #487 locally, but I think the issue could be caused by a redirect that Chrome has some kind of undocumented defenses against (insecure address surely isn't the issue). We're just going to try this address it redirects to

Please excuse me merging this without review: we're just changing a link to another valid link