### PR TITLE
Fix: Monster tokens throw Polyglot errors

### DIFF
--- a/src/module/actor/data-model-monster.js
+++ b/src/module/actor/data-model-monster.js
@@ -22,6 +22,30 @@ export default class OseDataModelMonster extends foundry.abstract.TypeDataModel 
       );
   }
 
+  /**
+   * @inheritdoc
+   */
+  static migrateData(source) {
+    this.#migrateMonsterLanguages(source);
+
+    return super.migrateData(source);
+  }
+
+  /**
+   * Use an empty array for system.languages.value
+   * in order to suppress Polyglot errors.
+   * 
+   * @param {OseDataModelMonster} source - Source data to migrate
+   */
+  static #migrateMonsterLanguages(source) {
+    const languages = source.languages ?? {};
+
+    // If languages.value isn't an iterable, use an empty array
+    if (typeof languages?.value?.[Symbol.iterator] !== "function") {
+      languages.value = [];
+    }
+  }
+
   // @todo define schema options; stuff like min/max values and so on.
   static defineSchema() {
     const { StringField, NumberField, BooleanField, ObjectField, SchemaField } =

--- a/template.json
+++ b/template.json
@@ -52,6 +52,9 @@
         "initiative": {
           "value": 0,
           "mod": 0
+        },
+        "languages": {
+          "value": []
         }
       },
       "spellcaster": {
@@ -131,9 +134,6 @@
       },
       "encumbrance": {
         "max": 1600
-      },
-      "languages": {
-        "value": []
       }
     },
     "monster": {


### PR DESCRIPTION
Whenever you select a monster token with the Polyglot mod enabled, it emits at least one console error telling you that it can't find the actor's languages because `system.languages.value` is undefined. As far as I know it's basically harmless, but depending on what I'm doing it can spit hundreds or **thousands** of bright red error messages that make debugging a pain. This quick fix eliminates the spam by placing an empty array where Polyglot expects to find it.