### PR TITLE
Fix: Item chat cards don't show

### DIFF
--- a/src/module/item/entity.js
+++ b/src/module/item/entity.js
@@ -399,7 +399,7 @@ export default class OseItem extends Item {
     // Basic chat message data
     const chatData = {
       user: game.user.id,
-      type: CONST.CHAT_MESSAGE_STYLES.OTHER,
+      type: CONST.CHAT_MESSAGE_TYPES.OTHER,
       content: html,
       speaker: {
         actor: this.actor.id,


### PR DESCRIPTION
Resolves #524.

The method that shows the chat card for an item/ability was referencing `CONST.CHAT_MESSAGE_STYLES` instead of `CONST.CHAT_MESSAGE_TYPES`, which exists. As noted in the issue comments, fixing the reference fixes the behavior. Tested in v11.