### PR TITLE
Fix: Error on new actor creation

### DIFF
--- a/src/module/actor/data-model-classes/data-model-character-scores.ts
+++ b/src/module/actor/data-model-classes/data-model-character-scores.ts
@@ -145,12 +145,12 @@ export default class OseDataModelCharacterScores implements CharacterScores {
    * @param {string} scores.cha - The character's charisma
    */
   constructor({ str, int, wis, dex, con, cha }: Scores) {
-    this.#str = str;
-    this.#int = int;
-    this.#wis = wis;
-    this.#dex = dex;
-    this.#con = con;
-    this.#cha = cha;
+    this.#str = str ?? 0;
+    this.#int = int ?? 0;
+    this.#wis = wis ?? 0;
+    this.#dex = dex ?? 0;
+    this.#con = con ?? 0;
+    this.#cha = cha ?? 0;
   }
 
   get str() {


### PR DESCRIPTION
Creating a new "character" Actor throws a data preparation error because one or more properties aren't being set before they're accessed. It seems like it's because undefined data is being passed into the `OseDataModelCharacterScores` constructor, since this little hack is enough to fix the error. Harmless as far as I can tell, but those red console messages bug me XD