### PR TITLE
Fix: Don't reroll zero init at start of combat

### DIFF
--- a/src/module/combat.js
+++ b/src/module/combat.js
@@ -78,7 +78,7 @@ const OseCombat = {
     for (let i = 0; i < combatants.size; i++) {
       const c = combatants.contents[i];
       // check if actor initiative has already been set for round 1
-      if (c?.initiative && combat.round === 0) {
+      if (c?.initiative != null && combat.round === 0) {
         continue;
       }
       // This comes from foundry.js, had to remove the update turns thing


### PR DESCRIPTION
There's a bit of an edge case in the individual initiative code: if a combatant rolls _exactly_ 0 for their initiative (i.e. due to a penalty) after a combat is created but _before_ combat begins, their initiative will be rerolled at the start of combat because the tracker incorrectly assumes it hasn't been. Checking if the value is nullish, instead of falsy, lets the system distinguish between unrolled init and the number 0.