### PR TITLE
Fix for Treasure Tables not computing successful results.

### DIFF
--- a/src/module/helpers-treasure.js
+++ b/src/module/helpers-treasure.js
@@ -123,12 +123,12 @@ export async function rollTreasure(table, options = {}) {
   const html = await renderTemplate(
     `${OSE.systemPath()}/templates/chat/roll-treasure.html`,
     templateData
-    );
+  );
 
   const chatData = {
     content: html,
     // sound: "systems/ose/assets/coins.mp3"
-    };
+  };
 
   const rollMode = game.settings.get("core", "rollMode");
   if (["gmroll", "blindroll"].includes(rollMode))

--- a/src/module/helpers-treasure.js
+++ b/src/module/helpers-treasure.js
@@ -119,25 +119,24 @@ export async function rollTreasure(table, options = {}) {
     });
   }
   
-  setTimeout(async () => {
-    const html = await renderTemplate(
-        `${OSE.systemPath()}/templates/chat/roll-treasure.html`,
-        templateData
-      );
+  await new Promise(resolve => requestAnimationFrame(resolve));
+  const html = await renderTemplate(
+    `${OSE.systemPath()}/templates/chat/roll-treasure.html`,
+    templateData
+    );
 
-      const chatData = {
-        content: html,
-        // sound: "systems/ose/assets/coins.mp3"
-      };
-    
-      const rollMode = game.settings.get("core", "rollMode");
-      if (["gmroll", "blindroll"].includes(rollMode))
-        chatData.whisper = ChatMessage.getWhisperRecipients("GM");
-      if (rollMode === "selfroll") chatData.whisper = [game.user._id];
-      if (rollMode === "blindroll") chatData.blind = true;
-    
-      ChatMessage.create(chatData);
-    }, 0);
+  const chatData = {
+    content: html,
+    // sound: "systems/ose/assets/coins.mp3"
+    };
+
+  const rollMode = game.settings.get("core", "rollMode");
+  if (["gmroll", "blindroll"].includes(rollMode))
+    chatData.whisper = ChatMessage.getWhisperRecipients("GM");
+  if (rollMode === "selfroll") chatData.whisper = [game.user._id];
+  if (rollMode === "blindroll") chatData.blind = true;
+
+  ChatMessage.create(chatData);
 }
 
 export const functionsForTesting = {

--- a/src/module/helpers-treasure.js
+++ b/src/module/helpers-treasure.js
@@ -118,24 +118,26 @@ export async function rollTreasure(table, options = {}) {
       }
     });
   }
+  
+  setTimeout(async () => {
+    const html = await renderTemplate(
+        `${OSE.systemPath()}/templates/chat/roll-treasure.html`,
+        templateData
+      );
 
-  const html = await renderTemplate(
-    `${OSE.systemPath()}/templates/chat/roll-treasure.html`,
-    templateData
-  );
-
-  const chatData = {
-    content: html,
-    // sound: "systems/ose/assets/coins.mp3"
-  };
-
-  const rollMode = game.settings.get("core", "rollMode");
-  if (["gmroll", "blindroll"].includes(rollMode))
-    chatData.whisper = ChatMessage.getWhisperRecipients("GM");
-  if (rollMode === "selfroll") chatData.whisper = [game.user._id];
-  if (rollMode === "blindroll") chatData.blind = true;
-
-  ChatMessage.create(chatData);
+      const chatData = {
+        content: html,
+        // sound: "systems/ose/assets/coins.mp3"
+      };
+    
+      const rollMode = game.settings.get("core", "rollMode");
+      if (["gmroll", "blindroll"].includes(rollMode))
+        chatData.whisper = ChatMessage.getWhisperRecipients("GM");
+      if (rollMode === "selfroll") chatData.whisper = [game.user._id];
+      if (rollMode === "blindroll") chatData.blind = true;
+    
+      ChatMessage.create(chatData);
+      }, 0);
 }
 
 export const functionsForTesting = {

--- a/src/module/helpers-treasure.js
+++ b/src/module/helpers-treasure.js
@@ -73,7 +73,7 @@ async function drawTreasure(table, data) {
         const text = r.getChatText(r);
         data.treasure[r.id] = {
           img: r.img,
-          text: TextEditor.enrichHTML(text, { async: false }),
+          text: await TextEditor.enrichHTML(text, { async: true }),
         };
         if (
           r.type === CONST.TABLE_RESULT_TYPES.DOCUMENT &&

--- a/src/module/helpers-treasure.js
+++ b/src/module/helpers-treasure.js
@@ -137,7 +137,7 @@ export async function rollTreasure(table, options = {}) {
       if (rollMode === "blindroll") chatData.blind = true;
     
       ChatMessage.create(chatData);
-      }, 0);
+    }, 0);
 }
 
 export const functionsForTesting = {


### PR DESCRIPTION
I noticed that the Treasure Tables were always returning No Results.  I looked into it and apparently the docs are wrong for TextEditor.enrichHTML() because it is returning a promise of a string, not a string.  This just awaits that call, which fixes the Treasure Table rolling.  Yay!