### PR TITLE
Fix: Slow weapons forgetting their slowness

### DIFF
--- a/src/module/actor/data-model-character.js
+++ b/src/module/actor/data-model-character.js
@@ -204,7 +204,7 @@ export default class OseDataModelCharacter extends foundry.abstract.TypeDataMode
   get isSlow() {
     return this.weapons.length === 0
       ? false
-      : this.weapons.every(
+      : this.weapons.some(
           (item) =>
             !(
               item.type !== "weapon" ||


### PR DESCRIPTION
Having a Slow weapon equipped currently only slows you down in group initiative if it's the _only_ weapon you have outside of a container. Turns out the isSlow property on the Actor is only true if _all_ of their weapons are both Slow and equipped. Individual initiative likely has the same issue and this change probably fixes that too.